### PR TITLE
fix: correct find_up to print root dir instead of file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ files:
 
 ```nix
 { nixpkgs, treefmt-nix, ... }:
-treefmt-nix.mkWrapper nixpkgs {
+treefmt-nix.lib.mkWrapper nixpkgs {
   # Used to find the project root
   projectRootFile = ".git/config";
   # Enable the terraform formatter

--- a/module-options.nix
+++ b/module-options.nix
@@ -99,7 +99,7 @@ in
         ancestors=()
         while true; do
           if [[ -f $1 ]]; then
-            echo "$PWD/$1"
+            echo "$PWD"
             exit 0
           fi
           ancestors+=("$PWD")


### PR DESCRIPTION
In its current form, `find_up` passes an invalid value for `$tree_root` to `treefmt`, resulting in the following error:

```
.nixpkgs on  master [$✘!+⇡] via ❄️  impure (devshell) on ☁️  snip
❯ treefmt -v
[DEBUG]: tree_root=/Users/kclejeune/.nixpkgs/flake.nix work_dir=/Users/kclejeune/.nixpkgs cache_dir=/Users/kclejeune/Library/Caches/com.NumTide.treefmt/eval-cache config_file=/nix/store/mwiijsrkrcnggq1gn6zvz7sj60pb0812-treefmt.toml paths=["/Users/kclejeune/.nixpkgs/flake.nix"]
[DEBUG]: load config: 167.79µs (Δ 167.79µs)
[DEBUG]: Found /nix/store/7hwn4c79z2gi97br6d6gmmq2mnakbcvx-alejandra-3.0.0/bin/alejandra at /nix/store/7hwn4c79z2gi97br6d6gmmq2mnakbcvx-alejandra-3.0.0/bin/alejandra
[DEBUG]: built glob set; 0 literals, 0 basenames, 0 extensions, 0 prefixes, 0 suffixes, 1 required extensions, 0 regexes
... # snip
[DEBUG]: load formatters: 1.29ms (Δ 1.12ms)
[DEBUG]: cache: loading from /Users/kclejeune/Library/Caches/com.NumTide.treefmt/eval-cache/7c58c3ccf597863859d3e41fc36d0286c45b6f73.toml
[DEBUG]: load cache: 1.57ms (Δ 281.96µs)
[DEBUG]: tree walk: 2.25ms (Δ 674.21µs)
[DEBUG]: filter_matches: 2.27ms (Δ 26.75µs)
[DEBUG]: running "/nix/store/7hwn4c79z2gi97br6d6gmmq2mnakbcvx-alejandra-3.0.0/bin/alejandra" "/Users/kclejeune/.nixpkgs/flake.nix"
[ERR]: #alejandra failed: Not a directory (os error 20)
```

This sets `tree_root` according to the parent path of the `projectRootFile`, rather than the filepath itself.