### PR TITLE
rustfmt: fix package

### DIFF
--- a/programs/rustfmt.nix
+++ b/programs/rustfmt.nix
@@ -12,7 +12,7 @@ in
         Rust edition to target when formatting
       '';
     };
-    package = lib.mkPackageOption pkgs "rustc" { };
+    package = lib.mkPackageOption pkgs "rustfmt" { };
   };
 
   config = lib.mkIf cfg.enable {


### PR DESCRIPTION
rustc package actually does not contain rustfmt.