### PR TITLE
Add `flake-parts` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This flake exposes a [flake-parts](https://flake.parts/) module as well. To use 
 
 1. Add `inputs.treefmt-nix.flakeModule` to the "imports" list of your `flake-parts` call.
 1. Add `treefmt = { .. }` (containing the configuration above) to your "perSystem" section.
-1. Add `config.treefmt.build.wrapper` to the `buildInputs` of your devShell. This will make the `treefmt` command available in the shell using the specified configuration.
+1. Add `config.treefmt.build.wrapper` to the `nativeBuildInputs` of your devShell. This will make the `treefmt` command available in the shell using the specified configuration.
     - You can also use `config.treefmt.build.programs` to get access to the individual programs, which could be useful to provide them to your IDE or editor.
 
 For an example, see [haskell-template](https://github.com/srid/haskell-template)'s `flake.nix`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ treefmt-nix.lib.mkWrapper nixpkgs {
 }
 ```
 
+### `flake-parts`
+
+This flake exposes a [flake-parts](https://flake.parts/) module as well. To use it:
+
+1. Add `inputs.treefmt-nix.flakeModule` to the "imports" list of your `flake-parts` call.
+1. Add `treefmt = { .. }` (containing the configuration above) to your "perSystem" section.
+1. Add `config.treefmt.build.wrapper` to the `buildInputs` of your devShell. This will make the `treefmt` command available in the shell using the specified configuration.
+    - You can also use `config.treefmt.build.programs` to get access to the individual programs, which could be useful to provide them to your IDE or editor.
+
+For an example, see [haskell-template](https://github.com/srid/haskell-template)'s `flake.nix`.
+
 ## Supported programs
 
 <!-- `> ls programs/*.nix | grep -v default.nix | cut -d '.' -f 1 | cut -d / -f 2 | sort | sed -e 's/^/* /'` -->

--- a/default.nix
+++ b/default.nix
@@ -7,23 +7,24 @@ let
   # Program to formatter mapping
   programs = import ./programs;
 
+  all-modules = nixpkgs: [
+    {
+      _module.args = {
+        pkgs = nixpkgs;
+        lib = nixpkgs.lib;
+      };
+    }
+    module-options
+  ]
+  ++ programs.modules;
+
   # Use the Nix module system to validate the treefmt config file format.
   #
   # nixpkgs is an instance of <nixpkgs> that contains treefmt.
   # configuration is an attrset used to configure the nix module
   evalModule = nixpkgs: configuration:
     nixpkgs.lib.evalModules {
-      modules = [
-        {
-          _module.args = {
-            pkgs = nixpkgs;
-            lib = nixpkgs.lib;
-          };
-        }
-        module-options
-      ]
-      ++ programs.modules
-      ++ [ configuration ];
+      modules = all-modules nixpkgs ++ [ configuration ];
     };
 
   # Returns a treefmt.toml generated from the passed configuration.
@@ -50,6 +51,7 @@ in
   inherit
     module-options
     programs
+    all-modules
     evalModule
     mkConfigFile
     mkWrapper

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -1,4 +1,3 @@
-{ treefmtLib }:
 { self, lib, flake-parts-lib, ... }:
 let
   inherit (flake-parts-lib)
@@ -8,7 +7,6 @@ let
     types;
 in
 {
-  _file = __curPos.file;
   options = {
     perSystem = mkPerSystemOption
       ({ config, self', inputs', pkgs, system, ... }: {
@@ -26,7 +24,7 @@ in
                 type = types.raw; # TODO: module type?
                 description = "Evaluated module of treefmt-nix";
                 default =
-                  treefmtLib.evalModule pkgs config.treefmt.config;
+                  (import ./.).evalModule pkgs config.treefmt.config;
               };
               programs = mkOption {
                 type = types.attrsOf types.package;

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -53,7 +53,7 @@ in
     perSystem = { config, self', inputs', pkgs, ... }: {
       checks.treefmt = pkgs.runCommandLocal "treefmt-check"
         {
-          buildInputs = [ pkgs.git config.treefmt.wrapper ] ++ config.treefmt.programs;
+          buildInputs = [ pkgs.git config.treefmt.wrapper ] ++ lib.attrValues config.treefmt.programs;
         }
         ''
           set -e

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -52,19 +52,14 @@ in
             }
             ''
               set -e
-              # treefmt uses a cache at $HOME. But we can use --no-cache
-              # to make treefmt not use a cache. We still seem to need
-              # to export a writable $HOME though.
-              # TODO: https://github.com/numtide/treefmt/pull/174 fixes this issue
-              # but we need to wait until a release is made and that release gets
-              # into the nixpkgs we use.
-              export HOME="$TMP"
+              treefmt --version
               # `treefmt --fail-on-change` is broken for purs-tidy; So we must rely
               # on git to detect changes. An unintended advantage of this approach
               # is that when the check fails, it will print a helpful diff at the end.
-              cp -r ${self} $HOME/project
-              chmod -R a+w $HOME/project
-              cd $HOME/project
+              PRJ=$TMP/project
+              cp -r ${self} $PRJ
+              chmod -R a+w $PRJ
+              cd $PRJ
               git init
               git config user.email "nix@localhost"
               git config user.name Nix

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -47,39 +47,37 @@ in
             };
           };
         };
+        config = {
+          checks.treefmt = pkgs.runCommandLocal "treefmt-check"
+            {
+              buildInputs = [ pkgs.git config.treefmt.wrapper ] ++ lib.attrValues config.treefmt.programs;
+            }
+            ''
+              set -e
+              # treefmt uses a cache at $HOME. But we can use --no-cache
+              # to make treefmt not use a cache. We still seem to need
+              # to export a writable $HOME though.
+              # TODO: https://github.com/numtide/treefmt/pull/174 fixes this issue
+              # but we need to wait until a release is made and that release gets
+              # into the nixpkgs we use.
+              export HOME="$TMP"
+              # `treefmt --fail-on-change` is broken for purs-tidy; So we must rely
+              # on git to detect changes. An unintended advantage of this approach
+              # is that when the check fails, it will print a helpful diff at the end.
+              cp -r ${self} $HOME/project
+              chmod -R a+w $HOME/project
+              cd $HOME/project
+              git init
+              git config user.email "nix@localhost"
+              git config user.name Nix
+              git add .
+              git commit -m init
+              treefmt --no-cache
+              git status
+              git --no-pager diff --exit-code
+              touch $out
+            '';
+        };
       });
-  };
-  config = {
-    perSystem = { config, self', inputs', pkgs, ... }: {
-      checks.treefmt = pkgs.runCommandLocal "treefmt-check"
-        {
-          buildInputs = [ pkgs.git config.treefmt.wrapper ] ++ lib.attrValues config.treefmt.programs;
-        }
-        ''
-          set -e
-          # treefmt uses a cache at $HOME. But we can use --no-cache
-          # to make treefmt not use a cache. We still seem to need
-          # to export a writable $HOME though.
-          # TODO: https://github.com/numtide/treefmt/pull/174 fixes this issue
-          # but we need to wait until a release is made and that release gets
-          # into the nixpkgs we use.
-          export HOME="$TMP"
-          # `treefmt --fail-on-change` is broken for purs-tidy; So we must rely
-          # on git to detect changes. An unintended advantage of this approach
-          # is that when the check fails, it will print a helpful diff at the end.
-          cp -r ${self} $HOME/project
-          chmod -R a+w $HOME/project
-          cd $HOME/project
-          git init
-          git config user.email "nix@localhost"
-          git config user.name Nix
-          git add .
-          git commit -m init
-          treefmt --no-cache
-          git status
-          git --no-pager diff --exit-code
-          touch $out
-        '';
-    };
   };
 }

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -11,44 +11,13 @@ in
     perSystem = mkPerSystemOption
       ({ config, self', inputs', pkgs, system, ... }: {
         options.treefmt = mkOption {
-          description = ''
-            treefmt flake module options
-          '';
-          type = types.submodule {
-            options = {
-              config = mkOption {
-                description = "treefmt-nix configuration";
-                type = types.submoduleWith {
-                  modules = (import ./.).all-modules pkgs;
-                };
-              };
-              module = mkOption {
-                type = types.raw; # TODO: module type?
-                description = "Evaluated module of treefmt-nix";
-                default =
-                  (import ./.).evalModule pkgs config.treefmt.config;
-              };
-              programs = mkOption {
-                type = types.attrsOf types.package;
-                description = "Attrset of formatter programs enabled in configuration";
-                default =
-                  pkgs.lib.concatMapAttrs
-                    (k: v:
-                      if v.enable
-                      then { "${k}" = v.package; }
-                      else { })
-                    config.treefmt.module.config.programs;
-              };
-              wrapper = mkOption {
-                type = types.package;
-                description = "Wrapper treefmt using the current configuration";
-                default = config.treefmt.module.config.build.wrapper;
-              };
-            };
+          description = "treefmt-nix configuration";
+          type = types.submoduleWith {
+            modules = (import ./.).all-modules pkgs;
           };
         };
         config = {
-          checks.treefmt = config.treefmt.module.config.build.check self;
+          checks.treefmt = config.treefmt.build.check self;
         };
       });
   };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -18,7 +18,9 @@ in
             options = {
               config = mkOption {
                 description = "treefmt-nix configuration";
-                type = types.raw; # TODO: Should use module-options.nix
+                type = types.submoduleWith {
+                  modules = (import ./.).all-modules pkgs;
+                };
               };
               module = mkOption {
                 type = types.raw; # TODO: module type?

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -48,30 +48,7 @@ in
           };
         };
         config = {
-          checks.treefmt = pkgs.runCommandLocal "treefmt-check"
-            {
-              buildInputs = [ pkgs.git config.treefmt.wrapper ] ++ lib.attrValues config.treefmt.programs;
-            }
-            ''
-              set -e
-              treefmt --version
-              # `treefmt --fail-on-change` is broken for purs-tidy; So we must rely
-              # on git to detect changes. An unintended advantage of this approach
-              # is that when the check fails, it will print a helpful diff at the end.
-              PRJ=$TMP/project
-              cp -r ${self} $PRJ
-              chmod -R a+w $PRJ
-              cd $PRJ
-              git init
-              git config user.email "nix@localhost"
-              git config user.name Nix
-              git add .
-              git commit -m init
-              treefmt --no-cache
-              git status
-              git --no-pager diff --exit-code
-              touch $out
-            '';
+          checks.treefmt = config.treefmt.module.config.build.check self;
         };
       });
   };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -11,7 +11,9 @@ in
     perSystem = mkPerSystemOption
       ({ config, self', inputs', pkgs, system, ... }: {
         options.treefmt = mkOption {
-          description = "treefmt-nix configuration";
+          description = ''
+            Project-level treefmt configuration
+          '';
           type = types.submoduleWith {
             modules = (import ./.).all-modules pkgs;
           };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -1,0 +1,85 @@
+{ treefmtLib }:
+{ self, lib, flake-parts-lib, ... }:
+let
+  inherit (flake-parts-lib)
+    mkPerSystemOption;
+  inherit (lib)
+    mkOption
+    types;
+in
+{
+  _file = __curPos.file;
+  options = {
+    perSystem = mkPerSystemOption
+      ({ config, self', inputs', pkgs, system, ... }: {
+        options.treefmt = mkOption {
+          description = ''
+            treefmt flake module options
+          '';
+          type = types.submodule {
+            options = {
+              config = mkOption {
+                description = "treefmt-nix configuration";
+                type = types.raw; # TODO: Should use module-options.nix
+              };
+              module = mkOption {
+                type = types.raw; # TODO: module type?
+                description = "Evaluated module of treefmt-nix";
+                default =
+                  treefmtLib.evalModule pkgs config.treefmt.config;
+              };
+              programs = mkOption {
+                type = types.attrsOf types.package;
+                description = "Attrset of formatter programs enabled in configuration";
+                default =
+                  pkgs.lib.concatMapAttrs
+                    (k: v:
+                      if v.enable
+                      then { "${k}" = v.package; }
+                      else { })
+                    config.treefmt.module.config.programs;
+              };
+              wrapper = mkOption {
+                type = types.package;
+                description = "Wrapper treefmt using the current configuration";
+                default = config.treefmt.module.config.build.wrapper;
+              };
+            };
+          };
+        };
+      });
+  };
+  config = {
+    perSystem = { config, self', inputs', pkgs, ... }: {
+      checks.treefmt = pkgs.runCommandLocal "treefmt-check"
+        {
+          buildInputs = [ pkgs.git config.treefmt.wrapper ] ++ config.treefmt.programs;
+        }
+        ''
+          set -e
+          # treefmt uses a cache at $HOME. But we can use --no-cache
+          # to make treefmt not use a cache. We still seem to need
+          # to export a writable $HOME though.
+          # TODO: https://github.com/numtide/treefmt/pull/174 fixes this issue
+          # but we need to wait until a release is made and that release gets
+          # into the nixpkgs we use.
+          export HOME="$TMP"
+          # `treefmt --fail-on-change` is broken for purs-tidy; So we must rely
+          # on git to detect changes. An unintended advantage of this approach
+          # is that when the check fails, it will print a helpful diff at the end.
+          cp -r ${self} $HOME/project
+          chmod -R a+w $HOME/project
+          cd $HOME/project
+          git init
+          git config user.email "nix@localhost"
+          git config user.name Nix
+          git add .
+          git commit -m init
+          treefmt --no-cache
+          git status
+          git --no-pager diff --exit-code
+          touch $out
+        '';
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,8 @@
 {
   description = "treefmt nix configuration modules";
 
-  outputs = { self }: {
+  outputs = { self }: rec {
     lib = import ./.;
+    flakeModule = import ./flake-module.nix { treefmtLib = lib; };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,8 @@
 {
   description = "treefmt nix configuration modules";
 
-  outputs = { self }: rec {
+  outputs = { self }: {
     lib = import ./.;
-    flakeModule = import ./flake-module.nix { treefmtLib = lib; };
+    flakeModule = ./flake-module.nix;
   };
 }

--- a/module-options.nix
+++ b/module-options.nix
@@ -115,7 +115,7 @@ in
         type = types.functionTo types.package;
         default = self: pkgs.runCommandLocal "treefmt-check"
           {
-            buildInputs = [ pkgs.git config.treefmt.wrapper ] ++ lib.attrValues config.treefmt.programs;
+            buildInputs = [ pkgs.git config.build.wrapper ];
           }
           ''
             set -e

--- a/module-options.nix
+++ b/module-options.nix
@@ -110,10 +110,10 @@ in
       programs = mkOption {
         type = types.attrsOf types.package;
         description = ''
-          Attrset of formatter programs enabled in treefmt configuration
+          Attrset of formatter programs enabled in treefmt configuration.
 
           The key of the attrset is the formatter name, with the value being the
-          packaged used to do the formatting.
+          package used to do the formatting.
         '';
         default =
           pkgs.lib.concatMapAttrs
@@ -126,7 +126,9 @@ in
       check = mkOption {
         description = ''
           Create a flake check to test that the given project tree is already
-          formatted
+          formatted.
+
+          Input argument is the path to the project tree (usually 'self').
         '';
         type = types.functionTo types.package;
         default = self: pkgs.runCommandLocal "treefmt-check"

--- a/module-options.nix
+++ b/module-options.nix
@@ -86,6 +86,7 @@ in
           The treefmt package, wrapped with the config file.
         '';
         type = types.package;
+        defaultText = lib.literalMD "wrapped `treefmt` command";
         default =
           pkgs.writeShellScriptBin "treefmt" ''
             find_up() {
@@ -115,6 +116,7 @@ in
           The key of the attrset is the formatter name, with the value being the
           package used to do the formatting.
         '';
+        defaultText = lib.literalMD "Programs used in configuration";
         default =
           pkgs.lib.concatMapAttrs
             (k: v:
@@ -131,6 +133,7 @@ in
           Input argument is the path to the project tree (usually 'self').
         '';
         type = types.functionTo types.package;
+        defaultText = lib.literalMD "Default check implementation";
         default = self: pkgs.runCommandLocal "treefmt-check"
           {
             buildInputs = [ pkgs.git config.build.wrapper ];

--- a/module-options.nix
+++ b/module-options.nix
@@ -107,6 +107,22 @@ in
             exec ${config.package}/bin/treefmt --config-file ${config.build.configFile} "$@" --tree-root "$tree_root"
           '';
       };
+      programs = mkOption {
+        type = types.attrsOf types.package;
+        description = ''
+          Attrset of formatter programs enabled in treefmt configuration
+
+          The key of the attrset is the formatter name, with the value being the
+          packaged used to do the formatting.
+        '';
+        default =
+          pkgs.lib.concatMapAttrs
+            (k: v:
+              if v.enable
+              then { "${k}" = v.package; }
+              else { })
+            config.programs;
+      };
       check = mkOption {
         description = ''
           Create a flake check to test that the given project tree is already


### PR DESCRIPTION
I'm opening a draft PR (instead of waiting for full implementation) just to get something working, as well as to get any early feedback. The commits in this PR can be squash merged (or I can rebase them if necessary) once ready.

This PR adds a `flake-parts` module for working with treefmt in the most ergonomic way. It also adds a flake check to test in CI that the source tree is formatted. You can see a demo here: https://github.com/srid/haskell-template/pull/75

Resolves #1 

- [x] Can the `types.raw` be replaced with appropriate types? See also: https://github.com/numtide/treefmt-nix/issues/2
- [x] Add documentation