### PR TITLE
Add stylish-haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ For an example, see [haskell-template](https://github.com/srid/haskell-template)
 * shellcheck
 * shfmt
 * stylua
+* stylish-haskell
 * terraform
 <!-- END mdsh -->
 

--- a/programs/stylish-haskell.nix
+++ b/programs/stylish-haskell.nix
@@ -1,0 +1,18 @@
+{ lib, pkgs, config, ... }:
+let
+  cfg = config.programs.stylish-haskell;
+in
+{
+  options.programs.stylish-haskell = {
+    enable = lib.mkEnableOption "stylish-haskell";
+    package = lib.mkPackageOption pkgs "stylish-haskell" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    settings.formatter.stylish-haskell = {
+      command = cfg.package;
+      options = [ "-i" "-r" ];
+      includes = [ "*.hs" ];
+    };
+  };
+}


### PR DESCRIPTION
People usually use stylish-haskell over ormolu (despite my own preferences). I added my own config and thought it'd be nice to contribute upstream.

@zimbatm+team: Please review these changes and LMK if they are appropriate.