### PR TITLE
flake-module: add treefmt app output

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -19,6 +19,10 @@ in
           };
         };
         config = {
+          apps.treefmt = {
+            type = "app";
+            program = "${self'.packages.treefmt}/bin/treefmt";
+          };
           checks.treefmt = config.treefmt.build.check self;
           packages.treefmt = config.treefmt.build.wrapper;
         };


### PR DESCRIPTION
For convenience I want to have a treefmt app. i.e. I don't want to add treefmt.wrapper to all my devshells and having a app I can simply run it by using `nix run`

EDIT: seems like `nix run` also picks up the `packages` output. IIRC this is not the case for all nix versions, so either close this PR or merge