### PR TITLE
feat: add buildifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ For an example, see [haskell-template](https://github.com/srid/haskell-template)
 <!-- BEGIN mdsh -->
 * alejandra
 * black
+* buildifier
 * cabal-fmt
 * elm-format
 * gofmt

--- a/programs/buildifier.nix
+++ b/programs/buildifier.nix
@@ -1,0 +1,18 @@
+{ lib, pkgs, config, ... }:
+let
+  cfg = config.programs.buildifier;
+in
+{
+  options.programs.buildifier = {
+    enable = lib.mkEnableOption "buildifier";
+    package = lib.mkPackageOption pkgs "buildifier" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    settings.formatter.buildifier = {
+      command = "${cfg.package}/bin/buildifier";
+      includes = [ "BUILD.bazel" "*.bzl" ];
+    };
+  };
+}
+


### PR DESCRIPTION
a bazel formatter


I've tried using this PR on a bazel project but I get:
```
[INFO]: Error using formatter #buildozer:
• [STDOUT]:

• [STDERR]:
/home/teto/nova/BUILD.bazel: error while executing commands [] on target /home/teto/nova/buildlib/default_extensions.bzl
```

I used to run `buildozer -r .`, how does treefmt run commands ? does it pass a
list of them to the "command" or does it call the binary for each file ?
