### PR TITLE
[ocamlformat]: trim option/value

### DIFF
--- a/programs/ocamlformat.nix
+++ b/programs/ocamlformat.nix
@@ -12,11 +12,12 @@ let
       optionValue = list:
         assert l.assertMsg (list != [ ]) "treefmt-nix: Unable to detect ocamlformat version from file";
         l.elemAt list (l.length list - 1);
+      trim = l.replaceStrings [ " " ] [ "" ];
     in
     l.getAttr "ocamlformat_${
       l.replaceStrings ["."] ["_"]
       (optionValue (l.findFirst (option: l.head option == "version") []
-          (l.map (n: l.splitString "=" n) (l.splitString "\n" (l.readFile configFile)))))
+          (l.map (n: l.splitString "=" (trim n)) (l.splitString "\n" (l.readFile configFile)))))
     }"
       pkgSet;
 in


### PR DESCRIPTION
My bad, forgot to trim the values to support spaced cases

e.g
```ocamlformat
version =  0.24.1
```