### PR TITLE
Fix and check docs

### DIFF
--- a/programs/ocamlformat.nix
+++ b/programs/ocamlformat.nix
@@ -28,8 +28,9 @@ in
 
     pkgs = l.mkOption {
       type = l.types.lazyAttrsOf l.types.raw;
-      description = "The package set used to get the ocamlformat package at a specific version. defaults to nixpkgs.";
+      description = "The package set used to get the ocamlformat package at a specific version.";
       default = pkgs;
+      defaultText = lib.literalMD "Nixpkgs from context";
     };
 
     configFile = l.mkOption {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd tests
-nix flake check --recreate-lock-file --show-trace
+echo
+echo Running tests...
+nix flake check ./tests --recreate-lock-file --show-trace
+
+echo
+echo Checking that the flake.parts docs build...
+nix build github:hercules-ci/flake.parts-website --override-input treefmt-nix . --show-trace --log-lines 1000 || {
+  echo
+  echo "Looks like the docs aren't quite ok yet."
+  echo "If there's a long stack trace, look for the keyword: option"
+  echo "Ping flake-parts / module system maintainer @roberth if the error is unclear."
+  # TODO After https://github.com/NixOS/nix/issues/7553 is resolved, review
+  #      --show-trace option and error elobaration.
+  exit 1
+}


### PR DESCRIPTION
This makes sure that the docs can be rendered.

The error was as follows, excluding the stack trace:

```
error: Most nixpkgs attributes are not supported when generating documentation.
       Please check with `--show-trace` to see which option leads to this `pkgs.AAAAAASomeThingsFailToEvaluate` reference. Often it can be cut short with a `defaultText` argument to `lib.mkOption`, or by escaping an option `example` using `lib.literalExpression`.
```