### PR TITLE
check: use UTF-8 before running `treefmt`

### DIFF
--- a/module-options.nix
+++ b/module-options.nix
@@ -172,6 +172,8 @@ in
               git init
               git add .
               git commit -m init --quiet
+              export LANG=C.UTF-8
+              export LC_ALL=C.UTF-8
               treefmt --no-cache
               git status
               git --no-pager diff --exit-code


### PR DESCRIPTION
This prevents failures like the following when running ormolu:

```
ormolu: libs/dns-util/src/Wire/Network/DNS/SRV.hs: hGetContents: invalid argument (invalid byte sequence)
```

cf. https://github.com/wireapp/wire-server/commit/56e6e614e75a497a2d8adc160b32b21456eef351

https://github.com/tweag/ormolu/issues/38#issuecomment-845841655