### PR TITLE
Update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677932085,
-        "narHash": "sha256-+AB4dYllWig8iO6vAiGGYl0NEgmMgGHpy9gzWJ3322g=",
+        "lastModified": 1679944645,
+        "narHash": "sha256-e5Qyoe11UZjVfgRfwNoSU57ZeKuEmjYb77B9IVW7L/M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89",
+        "rev": "4bb072f0a8b267613c127684e099a70e1f6ff106",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3c5319ad3aa51551182ac82ea17ab1c6b0f0df89' (2023-03-04)
  → 'github:nixos/nixpkgs/4bb072f0a8b267613c127684e099a70e1f6ff106' (2023-03-27)
```

This is in order to fix the following issue on macOS:

```
❯ ./examples.sh 
error: cycle detected in build of '/nix/store/i6ys3yj3bddlxzv5jrcawqwlncm7slix-ormolu-0.5.0.1.drv' in the references of output 'bin' from output 'out'
```