### PR TITLE
Fix option docs rendering

### DIFF
--- a/module-options.nix
+++ b/module-options.nix
@@ -88,9 +88,6 @@ in
         description = "The development shell with treefmt and its underlying programs";
         type = types.package;
         readOnly = true;
-        default = pkgs.mkShell {
-          nativeBuildInputs = [ config.build.wrapper ] ++ (lib.attrValues config.build.programs);
-        };
       };
       configFile = mkOption {
         description = ''
@@ -195,5 +192,8 @@ in
   # Config
   config.build = {
     configFile = configFormat.generate "treefmt.toml" config.settings;
+    devShell = pkgs.mkShell {
+      nativeBuildInputs = [ config.build.wrapper ] ++ (lib.attrValues config.build.programs);
+    };
   };
 }


### PR DESCRIPTION
devShell default value could not be rendered.
As a readOnly option, it only allows a single definition, so the priority does not matter.
The simplest solution is to make the definition not an option default so that its value is not rendered.

One day I'll add CI for the docs; need to work on the OSS use case a bit.