### PR TITLE
flake-parts: Allow configuring project root

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -36,11 +36,19 @@ in
                   Add a flake check to run `treefmt`
                 '';
               };
+              options.projectRoot = lib.mkOption {
+                type = types.path;
+                default = self;
+                description = ''
+                  Path to the root of the project on which treefmt operates
+                '';
+              };
+              
             }];
           };
         };
         config = {
-          checks = lib.mkIf config.treefmt.flakeCheck { treefmt = config.treefmt.build.check self; };
+          checks = lib.mkIf config.treefmt.flakeCheck { treefmt = config.treefmt.build.check config.treefmt.projectRoot; };
           formatter = lib.mkIf config.treefmt.flakeFormatter (lib.mkDefault config.treefmt.build.wrapper);
         };
       });

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -43,7 +43,7 @@ in
                   Path to the root of the project on which treefmt operates
                 '';
               };
-              
+
             }];
           };
         };

--- a/flake.lock
+++ b/flake.lock
@@ -18,20 +18,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "systems": "systems"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=",
-        "path": "/nix/store/g1pv78p6lk92hjzr7syrcihvj4rx1fnz-source",
-        "type": "path"
-      },
-      "original": {
-        "id": "systems",
-        "type": "indirect"
+        "nixpkgs": "nixpkgs"
       }
     }
   },


### PR DESCRIPTION
Without this, the flake check hardcodes `self`.

This is used here: https://github.com/srid/haskell-flake/pull/179 where the CI is building a subflake, whose treefmt needs to format files from repo root.