### PR TITLE
Fix flakes syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Running treefmt-nix with flakes isn't hard. The library is exposed as the `lib` 
       eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
 
       # Eval the treefmt modules from ./treefmt.nix
-      treefmtEval = eachSystem (pkgs: treefmt-nix.evalModule pkgs ./treefmt.nix);
+      treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs ./treefmt.nix);
     in
     {
       # for `nix fmt`


### PR DESCRIPTION
Just happened across this project but the flake directions in `README.md` didn't work as `evalModule` is under the `lib` attribute and the example `./treefmt.nix` file should be an attrset (based on this repo's own file) not a function.