### PR TITLE
Allow indent_size to be unset for shfmt

### DIFF
--- a/examples/formatter-shfmt.toml
+++ b/examples/formatter-shfmt.toml
@@ -3,4 +3,4 @@
 command = "shfmt"
 excludes = []
 includes = ["*.sh"]
-options = ["-i", "2", "-s", "-w"]
+options = ["-s", "-w"]

--- a/examples/formatter-shfmt.toml
+++ b/examples/formatter-shfmt.toml
@@ -3,4 +3,4 @@
 command = "shfmt"
 excludes = []
 includes = ["*.sh"]
-options = ["-s", "-w"]
+options = ["-i", "2", "-s", "-w"]

--- a/programs/shfmt.nix
+++ b/programs/shfmt.nix
@@ -7,8 +7,8 @@ in
     enable = lib.mkEnableOption "shfmt";
     package = lib.mkPackageOption pkgs "shfmt" { };
     indent_size = lib.mkOption {
-      type = lib.types.int;
-      default = 2;
+      type = lib.types.nullOr lib.types.int;
+      default = null;
       example = 4;
       description = lib.mdDoc ''
         Sets the number of spaces to be used in indentation. Uses tabs if set to zero.
@@ -19,7 +19,11 @@ in
   config = lib.mkIf cfg.enable {
     settings.formatter.shfmt = {
       command = cfg.package;
-      options = [ "-i" (toString cfg.indent_size) "-s" "-w" ];
+      options =
+        (if isNull cfg.indent_size
+        then [ ]
+        else [ "-i" (toString cfg.indent_size) ])
+        ++ [ "-s" "-w" ];
       includes = [ "*.sh" ];
     };
   };

--- a/programs/shfmt.nix
+++ b/programs/shfmt.nix
@@ -8,10 +8,12 @@ in
     package = lib.mkPackageOption pkgs "shfmt" { };
     indent_size = lib.mkOption {
       type = lib.types.nullOr lib.types.int;
-      default = null;
+      default = 2;
       example = 4;
       description = lib.mdDoc ''
-        Sets the number of spaces to be used in indentation. Uses tabs if set to zero.
+        Sets the number of spaces to be used in indentation. Uses tabs if set to
+        zero. If this is null, then [.editorconfig will be used to configure
+        shfmt](https://github.com/patrickvane/shfmt#description).
       '';
     };
   };
@@ -20,9 +22,8 @@ in
     settings.formatter.shfmt = {
       command = cfg.package;
       options =
-        (if isNull cfg.indent_size
-        then [ ]
-        else [ "-i" (toString cfg.indent_size) ])
+        (lib.optionals (!isNull cfg.indent_size)
+          [ "-i" (toString cfg.indent_size) ])
         ++ [ "-s" "-w" ];
       includes = [ "*.sh" ];
     };


### PR DESCRIPTION
So the defaults don’t get in the way of reading the config file.

Fixes #96.