### PR TITLE
Specify full path to formatters

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680945546,
-        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
+        "lastModified": 1691276849,
+        "narHash": "sha256-RNnrzxhW38SOFIF6TY/WaX7VB3PCkYFEeRE5YZU+wHw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
+        "rev": "5faab29808a2d72f4ee0c44c8e850e4e6ada972f",
         "type": "github"
       },
       "original": {

--- a/programs/alejandra.nix
+++ b/programs/alejandra.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.alejandra = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/alejandra";
       includes = [ "*.nix" ];
     };
   };

--- a/programs/beautysh.nix
+++ b/programs/beautysh.nix
@@ -18,7 +18,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.beautysh = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/beautysh";
       options = [ "-i" (toString cfg.indent_size) ];
       includes = [ "*.sh" ];
     };

--- a/programs/black.nix
+++ b/programs/black.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.black = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/black";
       includes = [ "*.py" ];
     };
   };

--- a/programs/cabal-fmt.nix
+++ b/programs/cabal-fmt.nix
@@ -17,7 +17,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.cabal-fmt = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/cabal-fmt";
       options = [ "--inplace" ];
       includes = [ "*.cabal" ];
     };

--- a/programs/deadnix.nix
+++ b/programs/deadnix.nix
@@ -13,7 +13,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.deadnix = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/deadnix";
       options =
         [ "--edit" ]
         ++ (lib.optional cfg.no-lambda-arg "--no-lambda-arg")

--- a/programs/dhall.nix
+++ b/programs/dhall.nix
@@ -17,7 +17,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.dhall = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/dhall";
       options = [ "format" ];
       includes = [ "*.dhall" ];
     };

--- a/programs/dprint.nix
+++ b/programs/dprint.nix
@@ -93,7 +93,7 @@ in
           configFile = mkConfigFile { config = cfg.config; };
           x = pkgs.writeShellScriptBin "dprint" ''
             set -euo pipefail
-            exec ${lib.getExe cfg.package} --config=${configFile} "$@"
+            exec ${lib.getBin cfg.package}/bin/dprint --config=${configFile} "$@"
           '';
         in
         (x // { meta = config.package.meta // x.meta; });

--- a/programs/elm-format.nix
+++ b/programs/elm-format.nix
@@ -17,7 +17,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.elm-format = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/elm-format";
       options = [ " - -yes " ];
       includes = [ " * .elm " ];
     };

--- a/programs/fnlfmt.nix
+++ b/programs/fnlfmt.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.fnlfmt = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/fnlfmt";
       options = [ "--fix" ];
       includes = [ "*.fnl" ];
     };

--- a/programs/gofumpt.nix
+++ b/programs/gofumpt.nix
@@ -17,7 +17,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.gofumpt = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/gofumpt";
       options = [ "-w" ] ++ lib.optional cfg.extra "-extra";
       includes = [ "*.go" ];
     };

--- a/programs/google-java-format.nix
+++ b/programs/google-java-format.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.google-java-format = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/google-java-format";
       options = [ "--replace" ];
       includes = [ "*.java" ];
     };

--- a/programs/hclfmt.nix
+++ b/programs/hclfmt.nix
@@ -11,7 +11,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.hclfmt = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/hclfmt";
       options = [
         "-w" # write in place
       ];

--- a/programs/hlint.nix
+++ b/programs/hlint.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.hlint = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/hlint";
       options = [ "-j" ];
       includes = [ "*.hs" ];
     };

--- a/programs/isort.nix
+++ b/programs/isort.nix
@@ -17,7 +17,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.isort = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/isort";
       options = if cfg.profile != "" then [ "--profile" cfg.profile ] else [ ];
       includes = [ "*.py" ];
     };

--- a/programs/mdformat.nix
+++ b/programs/mdformat.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.mdformat = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/mdformat";
       includes = [ "*.md" ];
     };
   };

--- a/programs/mdsh.nix
+++ b/programs/mdsh.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.mdsh = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/mdsh";
       options = [ "--inputs" ];
       includes = [ "README.md" ];
     };

--- a/programs/nixfmt.nix
+++ b/programs/nixfmt.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.nixfmt = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/nixfmt";
       includes = [ "*.nix" ];
     };
   };

--- a/programs/nixpkgs-fmt.nix
+++ b/programs/nixpkgs-fmt.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.nixpkgs-fmt = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/nixpkgs-fmt";
       includes = [ "*.nix" ];
     };
   };

--- a/programs/ocamlformat.nix
+++ b/programs/ocamlformat.nix
@@ -20,6 +20,7 @@ let
           (l.map (n: l.splitString "=" (trim n)) (l.splitString "\n" (l.readFile configFile)))))
     }"
       pkgSet;
+
 in
 {
   options.programs.ocamlformat = {
@@ -44,7 +45,7 @@ in
     settings.formatter.ocamlformat = {
       command =
         if l.isNull cfg.configFile
-        then cfg.package
+        then "${lib.getBin cfg.package}/bin/ocamlformat"
         else detectVersion cfg.configFile cfg.pkgs;
       options = [ "-i" ];
       includes = [ "*.ml" "*.mli" ];

--- a/programs/ormolu.nix
+++ b/programs/ormolu.nix
@@ -14,7 +14,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.ormolu = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/ormolu";
       options = [
         "--mode"
         "inplace"

--- a/programs/purs-tidy.nix
+++ b/programs/purs-tidy.nix
@@ -17,7 +17,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.purs-tidy = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/purs-tidy";
       options = [ "format-in-place" ];
       includes = [
         "src/**/*.purs"

--- a/programs/ruff.nix
+++ b/programs/ruff.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.ruff = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/ruff";
       includes = [ "*.py" ];
     };
   };

--- a/programs/rufo.nix
+++ b/programs/rufo.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.rufo = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/rufo";
       options = [ "-x" ];
       includes = [ "*.rb" ];
     };

--- a/programs/scalafmt.nix
+++ b/programs/scalafmt.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.scalafmt = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/scalafmt";
       includes = [ "*.sbt" "*.scala" ];
     };
   };

--- a/programs/shellcheck.nix
+++ b/programs/shellcheck.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.shellcheck = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/shellcheck";
       includes = [ "*.sh" ];
     };
   };

--- a/programs/shfmt.nix
+++ b/programs/shfmt.nix
@@ -20,7 +20,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.shfmt = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/shfmt";
       options =
         (lib.optionals (!isNull cfg.indent_size)
           [ "-i" (toString cfg.indent_size) ])

--- a/programs/stylish-haskell.nix
+++ b/programs/stylish-haskell.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.stylish-haskell = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/stylish-haskell";
       options = [ "-i" "-r" ];
       includes = [ "*.hs" ];
     };

--- a/programs/stylua.nix
+++ b/programs/stylua.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.stylua = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/stylua";
       includes = [ "*.lua" ];
     };
   };

--- a/programs/taplo.nix
+++ b/programs/taplo.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.taplo = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/taplo";
       options = [ "format" ];
       includes = [ "*.toml" ];
     };

--- a/programs/terraform.nix
+++ b/programs/terraform.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.terraform = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/terraform";
       options = [ "fmt" ];
       includes = [ "*.tf" ];
     };

--- a/programs/yamlfmt.nix
+++ b/programs/yamlfmt.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.yamlfmt = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/yamlfmt";
       includes = [ "*.yaml" ];
     };
   };

--- a/programs/zprint.nix
+++ b/programs/zprint.nix
@@ -25,7 +25,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.zprint = {
-      command = cfg.package;
+      command = "${lib.getBin cfg.package}/bin/zprint";
       # zprint options must be first
       options = (lib.optional (cfg.zprintOpts != null) cfg.zprintOpts) ++ [ "--write" ];
       includes = [


### PR DESCRIPTION
`nix flake check` results in a warning stating that usage of package names for commands is deprecated, and a full path to the executable must be specified. Add `${lib.getBin cfg.package}/bin/foo` everywhere where only cfg.package is used to specify the command