### PR TITLE
add mypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ This repo contains a top-level `default.nix` that returns the library helper fun
 * mdformat
 * mdsh
 * mix-format
+* mypy
 * nixfmt
 * nixpkgs-fmt
 * ocamlformat

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -25,7 +25,8 @@ let
             } > "$out/${name}.toml"
           ''
         )
-        programConfigs;
+        # mypy example contains store paths
+        (lib.filterAttrs (n: _: n != "formatter-mypy") programConfigs);
     in
     pkgs.runCommand "examples" { } ''
       mkdir $out

--- a/programs/mypy.nix
+++ b/programs/mypy.nix
@@ -1,0 +1,61 @@
+{ lib, pkgs, config, ... }:
+{
+  options.programs.mypy = {
+    enable = lib.mkEnableOption "mypy";
+    directories = lib.mkOption {
+      description = "Directories to run mypy in";
+      type = lib.types.attrsOf
+        (lib.types.submodule (
+          { name, ... }:
+          {
+            options = {
+              directory = lib.mkOption {
+                type = lib.types.str;
+                default = name;
+                description = "Directory to run mypy in";
+              };
+              extraPythonPackages = lib.mkOption {
+                type = lib.types.listOf lib.types.package;
+                default = [ ];
+                example = lib.literalMD ''[ pkgs.python3.pkgs.requests ]'';
+                description = "Extra packages to add to PYTHONPATH";
+              };
+              modules = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [ "." ];
+                example = [ "mymodule" "tests" ];
+                description = "Modules to check";
+              };
+            };
+          }
+        ));
+      default = { "." = { }; };
+      example = {
+        "." = {
+          modules = [ "mymodule" "tests" ];
+        };
+        "./subdir" = {
+          modules = [ "." ];
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf config.programs.mypy.enable {
+    settings.formatter = lib.mapAttrs'
+      (name: cfg:
+        lib.nameValuePair "mypy-${name}" {
+          command = "sh";
+          options = [
+            "-eucx"
+            ''
+              cd "${cfg.directory}"
+              export PYTHONPATH="${pkgs.python3.pkgs.makePythonPath cfg.extraPythonPackages}"
+              ${lib.getExe pkgs.mypy} ${lib.escapeShellArgs cfg.modules}
+            ''
+          ];
+          includes = builtins.map (module: "${cfg.directory}/${module}/**/*.py") cfg.modules;
+        })
+      config.programs.mypy.directories;
+  };
+}


### PR DESCRIPTION
Unlike normal formatter type checking always needs to take the whole module into account.
That's why cannot just pass single files to mypy. This shouldn't be a problem because mypy never actually format files.