### PR TITLE
dhall: Add support for `lint`

### DIFF
--- a/programs/dhall.nix
+++ b/programs/dhall.nix
@@ -4,21 +4,19 @@ let
 in
 {
   options.programs.dhall = {
-    enable = lib.mkEnableOption "dhall";
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.dhall;
-      defaultText = lib.literalExpression "pkgs.dhall";
-      description = lib.mdDoc ''
-        dhall derivation to use.
-      '';
+    enable = lib.mkEnableOption "Dhall";
+    lint = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = lib.mdDoc "Whether to lint in addition to formatting.";
     };
+    package = lib.mkPackageOption pkgs "Dhall" { default = [ "dhall" ]; };
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.dhall = {
       command = cfg.package;
-      options = [ "format" ];
+      options = [ (if cfg.lint then "lint" else "format") ];
       includes = [ "*.dhall" ];
     };
   };


### PR DESCRIPTION
This also makes some other minor changes to the Dhall module.