### PR TITLE
nickel: fix formatting subcommand syntax

### DIFF
--- a/programs/nickel.nix
+++ b/programs/nickel.nix
@@ -6,7 +6,7 @@ let
     set -euo pipefail
 
     for file in "$@"; do
-      ${cfg.package}/bin/nickel format --in-place --file "$file"
+      ${cfg.package}/bin/nickel format "$file"
     done
   '';
 in


### PR DESCRIPTION
Current nickel version automatically formats the file in place and produces an error if the flags are provided