### PR TITLE
Fix elm-format

### DIFF
--- a/examples/formatter-elm-format.toml
+++ b/examples/formatter-elm-format.toml
@@ -2,5 +2,5 @@
 [formatter.elm-format]
 command = "elm-format"
 excludes = []
-includes = [" * .elm "]
-options = [" - -yes "]
+includes = ["*.elm"]
+options = ["--yes"]

--- a/programs/elm-format.nix
+++ b/programs/elm-format.nix
@@ -18,8 +18,8 @@ in
   config = lib.mkIf cfg.enable {
     settings.formatter.elm-format = {
       command = cfg.package;
-      options = [ " - -yes " ];
-      includes = [ " * .elm " ];
+      options = [ "--yes" ];
+      includes = [ "*.elm" ];
     };
   };
 }


### PR DESCRIPTION
The formatting of the elm-format configuration contained additional whitespace due to which formatting did not pick up on the files.
