### PR TITLE
Configurable includes for elm-format

### DIFF
--- a/examples/formatter-elm-format.toml
+++ b/examples/formatter-elm-format.toml
@@ -2,5 +2,5 @@
 [formatter.elm-format]
 command = "elm-format"
 excludes = []
-includes = [" * .elm "]
-options = [" - -yes "]
+includes = ["*.elm"]
+options = ["--yes"]

--- a/programs/elm-format.nix
+++ b/programs/elm-format.nix
@@ -5,6 +5,7 @@ in
 {
   options.programs.elm-format = {
     enable = lib.mkEnableOption "elm-format";
+
     package = lib.mkOption {
       type = lib.types.package;
       default = pkgs.elmPackages.elm-format;
@@ -13,13 +14,20 @@ in
         elm-format derivation to use.
       '';
     };
+
+    includes = lib.mkOption {
+      description = "Path / file patterns to include for Biome";
+      type = lib.types.listOf lib.types.str;
+      example = [ "*.elm" ];
+      default = [ "*.elm" ];
+    };
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.elm-format = {
       command = cfg.package;
       options = [ "--yes" ];
-      includes = [ "*.elm" ];
+      inherit (cfg) includes;
     };
   };
 }

--- a/programs/elm-format.nix
+++ b/programs/elm-format.nix
@@ -18,8 +18,8 @@ in
   config = lib.mkIf cfg.enable {
     settings.formatter.elm-format = {
       command = cfg.package;
-      options = [ " - -yes " ];
-      includes = [ " * .elm " ];
+      options = [ "--yes" ];
+      includes = [ "*.elm" ];
     };
   };
 }


### PR DESCRIPTION
This change allows to pass a list of `includes` to the `elm-format` configuration and is an addition after #163.

I want to add this configuration option because in a project I generate a lot of Elm code from another tool. Those generated files are not checked in into source control and don't fully follow the `elm-format` code formatting.

With this change, I can pass include rules that allow me to only format the files that are actually part of the repository and ignore the generated files.

 ```nix
  programs.elm-format.enable = true;
  programs.elm-format.includes = [ "src/Main.elm" ];
```

Thank you for your time and for creating this tool.  
I'm not sure if the desired approach is to immediately create a PR, or first discuss why I would like to add this change.

I copied the code from the biome configuration and adapted it.