### PR TITLE
csharpier extensions

### DIFF
--- a/programs/csharpier.nix
+++ b/programs/csharpier.nix
@@ -2,7 +2,8 @@
 let
   cfg = config.programs.csharpier;
   inherit (lib) mkEnableOption mkOption mkPackageOption mkIf types;
-in {
+in
+{
   options.programs.csharpier = {
     enable = mkEnableOption "csharpier";
     package = mkPackageOption pkgs "csharpier" { };

--- a/programs/csharpier.nix
+++ b/programs/csharpier.nix
@@ -1,10 +1,25 @@
 { lib, pkgs, config, ... }:
-let cfg = config.programs.csharpier;
-in {
+let
+  cfg = config.programs.csharpier;
+  inherit (lib) mkEnableOption mkOption mkPackageOption types;
+in
+{
   options.programs.csharpier = {
-    enable = lib.mkEnableOption "csharpier";
-    package = lib.mkPackageOption pkgs "csharpier" { };
-    dotnet-sdk = lib.mkPackageOption pkgs "dotnet-sdk" { };
+    enable = mkEnableOption "csharpier";
+    package = mkPackageOption pkgs "csharpier" { };
+    dotnet-sdk = mkPackageOption pkgs "dotnet-sdk" { };
+
+    includes = mkOption {
+      description = "Path / file patterns to include for CSharpier";
+      type = types.listOf types.str;
+      default = [ "*.cs" ];
+    };
+
+    excludes = lib.mkOption {
+      description = "Path / file patterns to exclude for CSharpier";
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -16,7 +31,8 @@ in {
           dotnet-csharpier "$@"
         '';
       };
-      includes = [ "*.cs" ];
+      includes = cfg.includes;
+      excludes = cfg.excludes;
     };
   };
 }

--- a/programs/csharpier.nix
+++ b/programs/csharpier.nix
@@ -1,9 +1,8 @@
 { lib, pkgs, config, ... }:
 let
   cfg = config.programs.csharpier;
-  inherit (lib) mkEnableOption mkOption mkPackageOption types;
-in
-{
+  inherit (lib) mkEnableOption mkOption mkPackageOption mkIf types;
+in {
   options.programs.csharpier = {
     enable = mkEnableOption "csharpier";
     package = mkPackageOption pkgs "csharpier" { };
@@ -15,14 +14,14 @@ in
       default = [ "*.cs" ];
     };
 
-    excludes = lib.mkOption {
+    excludes = mkOption {
       description = "Path / file patterns to exclude for CSharpier";
-      type = lib.types.listOf lib.types.str;
+      type = types.listOf types.str;
       default = [ ];
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = mkIf cfg.enable {
     settings.formatter.csharpier = {
       command = pkgs.writeShellApplication {
         name = "dotnet-csharpier";


### PR DESCRIPTION
- **add nixfmt-rfc-style**
- **flake update**
- **add fantomas (#159)**
- **feat(programs): add templ (#161)**
- **feat(programs): add opa (#162)**
- **Fix elm-format**
- **Add changed `examples/formatter-elm-format.toml`**
- **Make elm-format `includes` configurable**
- **feat(programs): add dos2unix (#165)**
- **fix(programs): leptosfmt does not touch files anymore (#166)**
- **feat: add ts declaration extensions to ext.js (#168)**
- **Add `packer fmt` formatter (#169)**
- **add includes and excludes options for csharpier**
