### PR TITLE
php-cs-fixer: add configFile option

### DIFF
--- a/examples/formatter-php-cs-fixer.toml
+++ b/examples/formatter-php-cs-fixer.toml
@@ -3,4 +3,4 @@
 command = "php-cs-fixer"
 excludes = []
 includes = ["*.php"]
-options = ["fix"]
+options = ["fix", "--config", "./.php-cs-fixer.php"]

--- a/programs/php-cs-fixer.nix
+++ b/programs/php-cs-fixer.nix
@@ -1,17 +1,24 @@
 { lib, pkgs, config, ... }:
 let
+  inherit (lib) types;
   cfg = config.programs.php-cs-fixer;
 in
 {
   options.programs.php-cs-fixer = {
     enable = lib.mkEnableOption "php-cs-fixer";
     package = lib.mkPackageOption pkgs.phpPackages "php-cs-fixer" { };
+    configFile = lib.mkOption {
+      description = "Path to php-cs-fixer config file.";
+      type = types.oneOf [ types.str types.path ];
+      default = "./.php-cs-fixer.php";
+      example = "./.php-cs-fixer.dist.php";
+    };
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.php-cs-fixer = {
       command = "${cfg.package}/bin/php-cs-fixer";
-      options = [ "fix" ];
+      options = [ "fix" "--config" "${cfg.configFile}" ];
       includes = [ "*.php" ];
     };
   };


### PR DESCRIPTION
This fixes an issue with php-cs-fixer, where it throws an error about requiring the `--config` argument if multiple files to format are specified.