### PR TITLE
feat: make treefmt settings a freeform type

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -66,7 +66,10 @@ let
       (k: _: throw "The module documentation must not depend on pkgs attributes such as ${lib.strings.escapeNixIdentifier k}")
       pkgs
     // {
+      _type = "pkgs";
       inherit lib;
+      # Formats is ok and supported upstream too
+      inherit (pkgs) formats;
     };
 
   self = {

--- a/module-options.nix
+++ b/module-options.nix
@@ -20,51 +20,61 @@ let
       else lib.getExe res;
   };
 
+  configFormat = pkgs.formats.toml { };
+
   # The schema of the treefmt.toml data structure.
-  configSchema = {
-    global = {
-      excludes = mkOption {
-        description = "A global list of paths to exclude. Supports glob.";
-        type = types.listOf types.str;
-        default = [ ];
-        example = [ "./node_modules/**" ];
+  configSchema = mkOption {
+    default = { };
+    description = "The contents of treefmt.toml";
+    type = types.submodule {
+      freeformType = configFormat.type;
+      options = {
+
+        global = {
+          excludes = mkOption {
+            description = "A global list of paths to exclude. Supports glob.";
+            type = types.listOf types.str;
+            default = [ ];
+            example = [ "./node_modules/**" ];
+          };
+        };
+
+        formatter = mkOption {
+          type = types.attrsOf (types.submodule [
+            {
+              freeformType = configFormat.type;
+              options = {
+                command = mkOption {
+                  description = "Executable obeying the treefmt formatter spec";
+                  type = exeType;
+                };
+
+                options = mkOption {
+                  description = "List of arguments to pass to the command";
+                  type = types.listOf types.str;
+                  default = [ ];
+                };
+
+                includes = mkOption {
+                  description = "List of files to include for formatting. Supports globbing.";
+                  type = types.listOf types.str;
+                };
+
+                excludes = mkOption {
+                  description = "List of files to exclude for formatting. Supports globbing. Takes precedence over the includes.";
+                  type = types.listOf types.str;
+                  default = [ ];
+                };
+              };
+            }
+          ]);
+          default = { };
+          description = "Set of formatters to use";
+        };
       };
     };
 
-    formatter = mkOption {
-      type = types.attrsOf (types.submodule [
-        {
-          options = {
-            command = mkOption {
-              description = "Executable obeying the treefmt formatter spec";
-              type = exeType;
-            };
-
-            options = mkOption {
-              description = "List of arguments to pass to the command";
-              type = types.listOf types.str;
-              default = [ ];
-            };
-
-            includes = mkOption {
-              description = "List of files to include for formatting. Supports globbing.";
-              type = types.listOf types.str;
-            };
-
-            excludes = mkOption {
-              description = "List of files to exclude for formatting. Supports globbing. Takes precedence over the includes.";
-              type = types.listOf types.str;
-              default = [ ];
-            };
-          };
-        }
-      ]);
-      default = { };
-      description = "Set of formatters to use";
-    };
   };
-
-  configFormat = pkgs.formats.toml { };
 in
 {
   # Schema


### PR DESCRIPTION
Allows for experimenting with new config options in `treefmt` without having to update `treefmt-nix`, whilst at the same time retaining types for stable config options.

Will allow passing pipeline related options for `2.0.0-rc1` for example.