### PR TITLE
hclfmt: only format .hcl files

### DIFF
--- a/examples/formatter-hclfmt.toml
+++ b/examples/formatter-hclfmt.toml
@@ -2,5 +2,5 @@
 [formatter.hclfmt]
 command = "hclfmt"
 excludes = []
-includes = ["*.hcl", "*.tf"]
+includes = ["*.hcl"]
 options = ["-w"]

--- a/programs/hclfmt.nix
+++ b/programs/hclfmt.nix
@@ -17,8 +17,6 @@ in
       ];
       includes = [
         "*.hcl"
-        "*.tf"
-        # TODO: any other file extensions?
       ];
     };
   };


### PR DESCRIPTION
Avoid clashes with the `terraform` formatter who does a better job at formatting the ".tf" files, since it has more domain knowledge there.