### PR TITLE
actionlint: revert including action files

### DIFF
--- a/examples/formatter-actionlint.toml
+++ b/examples/formatter-actionlint.toml
@@ -2,5 +2,5 @@
 [formatter.actionlint]
 command = "actionlint"
 excludes = []
-includes = [".github/workflows/*.yml", ".github/actions/**/*.yml", ".github/workflows/*.yaml", ".github/actions/**/*.yaml"]
+includes = [".github/workflows/*.yml", ".github/workflows/*.yaml"]
 options = []

--- a/programs/actionlint.nix
+++ b/programs/actionlint.nix
@@ -13,9 +13,7 @@ in
       command = cfg.package;
       includes = [
         ".github/workflows/*.yml"
-        ".github/actions/**/*.yml"
         ".github/workflows/*.yaml"
-        ".github/actions/**/*.yaml"
       ];
     };
   };


### PR DESCRIPTION
Sorry, I think I misunderstood the way actionlint consumes the actions.yml files. It looks like passing the files directly isn't intended for actions.

> actionlint still focuses on checking workflow files. So there is no way to directly specify action.yml as an argument of actionlint command.

https://github.com/rhysd/actionlint/releases/tag/v1.7.0