### PR TITLE
flake-modules.nix: allow empty specification

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -51,6 +51,7 @@ in
 
             }];
           };
+          default = { };
         };
         config = {
           checks = lib.mkIf config.treefmt.flakeCheck { treefmt = config.treefmt.build.check config.treefmt.projectRoot; };


### PR DESCRIPTION
Specify the default value of perSystem option treefmt as { } (an empty set) in the flake module.

Fix the "option treefmt used but not defined" error when importing the flake module without adding configurations.

The following check using @zarelit's reproducer shows that the errors disappear after applying this change:
```sh
nix flake show github:zarelit/repro-treefmt-issue-78 --override-input treefmt-nix github:ShamrockLee/treefmt-nix/fix-flake-module-empty
```

This pull request closes #78

Cc:
@zarelit
@zimbatm