### PR TITLE
fix: only eval enable option if visible

### DIFF
--- a/module-options.nix
+++ b/module-options.nix
@@ -1,4 +1,5 @@
 { config
+, options
 , lib
 , pkgs
 , ...
@@ -197,11 +198,14 @@ in
           package used to do the formatting.
         '';
         defaultText = lib.literalMD "Programs used in configuration";
-        default = pkgs.lib.concatMapAttrs
-          (
-            k: v: if v.enable then { "${k}" = v.package; } else { }
-          )
-          config.programs;
+        default =
+          pkgs.lib.concatMapAttrs
+            (
+              k: v:
+                if options.programs.${k}.enable.visible && v.enable then
+                  { "${k}" = v.package; } else { }
+            )
+            config.programs;
       };
       check = mkOption {
         description = ''


### PR DESCRIPTION
When using `lib.mkRenamedOptionModule`, the trace warning is emitted whenever the option is accessed.

Because we iterate and check the .enable option of all the programs, the renamed option gets accessed all the time.

So we check if the option is "visible" before checking in, which `lib.mkRenamedOptionModule` sets to false.

Fixes #211