### PR TITLE
fixup! fix: only eval enable option if visible (#214)

### DIFF
--- a/module-options.nix
+++ b/module-options.nix
@@ -202,7 +202,7 @@ in
           pkgs.lib.concatMapAttrs
             (
               k: v:
-                if options.programs.${k}.enable.visible && v.enable then
+                if (options.programs.${k}.enable.visible or true) && v.enable then
                   { "${k}" = v.package; } else { }
             )
             config.programs;


### PR DESCRIPTION
Turns out not all options have the visible attribute.

Fixes https://github.com/numtide/treefmt-nix/pull/214#issuecomment-2282188773

/cc @phanirithvij 