### PR TITLE
fix: unset PRJ_ROOT to prevent impure behavior

### DIFF
--- a/module-options.nix
+++ b/module-options.nix
@@ -180,6 +180,7 @@ in
               else
                 ''
                   set -euo pipefail
+                  unset PRJ_ROOT
                   exec ${config.package}/bin/treefmt \
                     --config-file=${config.build.configFile} \
                     --tree-root-file=${config.projectRootFile} \


### PR DESCRIPTION
When the `PRJ_ROOT` environment variable is set, [`treefmt` will use it to populate the `--tree-root` option](https://github.com/numtide/treefmt/blob/31e363dbc7d99e83e9924be21e9e169bbfea98f3/docs/usage.md?plain=1#L24).
Also, both `--tree-root` and `--tree-root-file` options must not be set at the same time, otherwise leading to:
```
treefmt: error: --tree-root and --tree-root-file can't be used together
```

As the tree-fmt module is explicitly setting `--tree-root-file`, I don't see a justification to let `PRJ_ROOT` leak in this script.