### PR TITLE
{shellcheck,shfmt}: include `*.envrc.*` files

### DIFF
--- a/examples/formatter-shellcheck.toml
+++ b/examples/formatter-shellcheck.toml
@@ -2,5 +2,5 @@
 [formatter.shellcheck]
 command = "shellcheck"
 excludes = []
-includes = ["*.sh", "*.bash", "*.envrc"]
+includes = ["*.sh", "*.bash", "*.envrc", "*.envrc.*"]
 options = []

--- a/examples/formatter-shfmt.toml
+++ b/examples/formatter-shfmt.toml
@@ -2,5 +2,5 @@
 [formatter.shfmt]
 command = "shfmt"
 excludes = []
-includes = ["*.sh", "*.bash", "*.envrc"]
+includes = ["*.sh", "*.bash", "*.envrc", "*.envrc.*"]
 options = ["-i", "2", "-s", "-w"]

--- a/programs/shellcheck.nix
+++ b/programs/shellcheck.nix
@@ -18,6 +18,7 @@ in
         "*.bash"
         # direnv
         "*.envrc"
+        "*.envrc.*"
       ];
     };
   };

--- a/programs/shfmt.nix
+++ b/programs/shfmt.nix
@@ -32,6 +32,7 @@ in
         "*.bash"
         # direnv
         "*.envrc"
+        "*.envrc.*"
       ];
     };
   };


### PR DESCRIPTION
So that e.g. `.envrc.recommended` gets processed.