### PR TITLE
rustfmt: add skip children

### DIFF
--- a/examples/formatter-rustfmt.toml
+++ b/examples/formatter-rustfmt.toml
@@ -3,4 +3,4 @@
 command = "rustfmt"
 excludes = []
 includes = ["*.rs"]
-options = ["--edition", "2021"]
+options = ["--edition", "2021", "--config", "skip_children=true"]

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726481836,
-        "narHash": "sha256-MWTBH4dd5zIz2iatDb8IkqSjIeFum9jAqkFxgHLdzO4=",
+        "lastModified": 1726871744,
+        "narHash": "sha256-V5LpfdHyQkUF7RfOaDPrZDP+oqz88lTJrMT1+stXNwo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20f9370d5f588fb8c72e844c54511cab054b5f40",
+        "rev": "a1d92660c6b3b7c26fb883500a80ea9d33321be2",
         "type": "github"
       },
       "original": {

--- a/programs/rustfmt.nix
+++ b/programs/rustfmt.nix
@@ -20,7 +20,7 @@ in
   config = lib.mkIf cfg.enable {
     settings.formatter.rustfmt = {
       command = "${cfg.package}/bin/rustfmt";
-      options = [ "--edition" cfg.edition ];
+      options = [ "--edition" cfg.edition "--skip_children" ];
       includes = [ "*.rs" ];
     };
   };

--- a/programs/rustfmt.nix
+++ b/programs/rustfmt.nix
@@ -20,7 +20,7 @@ in
   config = lib.mkIf cfg.enable {
     settings.formatter.rustfmt = {
       command = "${cfg.package}/bin/rustfmt";
-      options = [ "--edition" cfg.edition "--skip_children" ];
+      options = [ "--edition" cfg.edition "--config" "skip_children=true" ];
       includes = [ "*.rs" ];
     };
   };


### PR DESCRIPTION
Currently, rustfmt will recursively format module out of line files which is counter to the standards stated for formatters. I am hoping to get a response from the rustfmt folks in particular as to the expected way to handle this but this is the solution I found that works. 

If they get back to me, I will update this PR. Otherwise, this should prevent rustfmt from going off and doing it's own thing. Probably not a huge deal but did seem relevant. 