### PR TITLE
meson: format all meson files

### DIFF
--- a/examples/formatter-meson.toml
+++ b/examples/formatter-meson.toml
@@ -2,5 +2,5 @@
 [formatter.meson]
 command = "meson"
 excludes = []
-includes = ["meson.build", "meson.options", "meson_options.txt"]
+includes = ["meson.build", "meson.options", "meson_options.txt", "*/meson.build", "*/meson.options", "*/meson_options.txt"]
 options = ["fmt", "-i"]

--- a/programs/meson.nix
+++ b/programs/meson.nix
@@ -22,6 +22,9 @@ in
         "meson.build"
         "meson.options"
         "meson_options.txt"
+        "*/meson.build"
+        "*/meson.options"
+        "*/meson_options.txt"
       ];
     };
   };

--- a/programs/meson.nix
+++ b/programs/meson.nix
@@ -7,7 +7,7 @@ let
   cfg = config.programs.meson;
 in
 {
-  meta.maintainers = [ ];
+  meta.maintainers = [ "RossSmyth" ];
 
   options.programs.meson = {
     enable = lib.mkEnableOption "meson";

--- a/programs/muon.nix
+++ b/programs/muon.nix
@@ -22,6 +22,9 @@ in
         "meson.build"
         "meson.options"
         "meson_options.txt"
+        "*/meson.build"
+        "*/meson.options"
+        "*/meson_options.txt"
       ];
     };
   };


### PR DESCRIPTION
Fixes #241 

Previously the formatters only globbed the top-level files. I tried several different combos and found these work. The other globs I tried:

`*/meson.build`
`**/meson.build`

Did not work. But these seem to.