### PR TITLE
wrapper: add treefmt-nix executable to output

### DIFF
--- a/module-options.nix
+++ b/module-options.nix
@@ -192,6 +192,7 @@ in
                     "$@"
                 '';
             x = pkgs.writeShellScriptBin "treefmt" code;
+            # used by tooling to detect if treefmt was wrapped or not
             y = pkgs.writeShellScriptBin "treefmt-nix" code;
           in
           (pkgs.symlinkJoin

--- a/module-options.nix
+++ b/module-options.nix
@@ -192,8 +192,16 @@ in
                     "$@"
                 '';
             x = pkgs.writeShellScriptBin "treefmt" code;
+            y = pkgs.writeShellScriptBin "treefmt-nix" code;
           in
-          (x // { meta = config.package.meta // x.meta; });
+          (pkgs.symlinkJoin
+            {
+              name = "treefmt-nix";
+              paths = [
+                x
+                y
+              ];
+            } // { meta = config.package.meta // x.meta; });
       };
       programs = mkOption {
         type = types.attrsOf types.package;


### PR DESCRIPTION
this makes it easier to integrate this into none-ls. Since the currently generated wrapper conflicts with the already existing treefmt executable and it's hard to detect if it's either the program which needs a configfile or the wrapper created by treefmt-nix.

Will follow this up with a PR to none-ls for a builtin plugin and afterwards a PR to nixvim to add an option to easily enable that plugin :)