### PR TITLE
buildifier: include all .bazel files by default

### DIFF
--- a/examples/formatter-buildifier.toml
+++ b/examples/formatter-buildifier.toml
@@ -2,5 +2,5 @@
 [formatter.buildifier]
 command = "buildifier"
 excludes = []
-includes = ["BUILD.bazel", "*.bzl"]
+includes = ["*.bazel", "*.bzl"]
 options = []

--- a/programs/buildifier.nix
+++ b/programs/buildifier.nix
@@ -10,7 +10,10 @@ in
     includes = mkOption {
       description = "Bazel file patterns to format";
       type = types.listOf types.str;
-      default = [ "BUILD.bazel" "*.bzl" ];
+      default = [
+        "*.bazel"
+        "*.bzl"
+      ];
     };
   };
 


### PR DESCRIPTION
For https://bazel.build/external/module.