### PR TITLE
just: include .justfile

### DIFF
--- a/programs/just.nix
+++ b/programs/just.nix
@@ -23,7 +23,7 @@ in
         "--" # bash swallows the second argument when using -c
       ];
       includes = [
-        "[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # 'justfile', case insensitive
+        "\.?[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # 'justfile' or '.justfile', case insensitive
       ];
     };
   };


### PR DESCRIPTION
This just makes the formatter work for hidden justfiles, `.justfile`.