### PR TITLE
deno: include more supported files by default

### DIFF
--- a/examples/formatter-deno.toml
+++ b/examples/formatter-deno.toml
@@ -2,5 +2,5 @@
 [formatter.deno]
 command = "deno"
 excludes = []
-includes = ["*.js", "*.json", "*.jsonc", "*.jsx", "*.markdown", "*.md", "*.ts", "*.tsx"]
+includes = ["*.css", "*.html", "*.js", "*.json", "*.jsonc", "*.jsx", "*.less", "*.markdown", "*.md", "*.sass", "*.scss", "*.ts", "*.tsx", "*.yaml", "*.yml"]
 options = ["fmt"]

--- a/programs/deno.nix
+++ b/programs/deno.nix
@@ -25,14 +25,21 @@ in
       description = "Path / file patterns to include for Deno";
       type = types.listOf types.str;
       default = [
+        "*.css"
+        "*.html"
         "*.js"
         "*.json"
         "*.jsonc"
         "*.jsx"
+        "*.less"
         "*.markdown"
         "*.md"
+        "*.sass"
+        "*.scss"
         "*.ts"
         "*.tsx"
+        "*.yaml"
+        "*.yml"
       ];
     };
 
@@ -47,7 +54,7 @@ in
   config = mkIf cfg.enable {
     settings.formatter.deno = {
       command = cfg.package;
-      options = [ "fmt" ];
+      options = lib.mkBefore [ "fmt" ];
       includes = cfg.includes;
       excludes = cfg.excludes;
     };


### PR DESCRIPTION
See https://docs.deno.com/runtime/reference/cli/formatter/#supported-file-types.