### PR TITLE
nixpkgs-fmt: add `includes` and `excludes` options

### DIFF
--- a/programs/nixpkgs-fmt.nix
+++ b/programs/nixpkgs-fmt.nix
@@ -8,12 +8,26 @@ in
   options.programs.nixpkgs-fmt = {
     enable = lib.mkEnableOption "nixpkgs-fmt";
     package = lib.mkPackageOption pkgs "nixpkgs-fmt" { };
+
+    includes = lib.mkOption {
+      description = "Path/file patterns to include for nixpkgs-fmt";
+      type = lib.types.listOf lib.types.str;
+      default = [ "*.nix" ];
+    };
+    excludes = lib.mkOption {
+      description = "Path/file patterns to exclude for nixpkgs-fmt";
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+    };
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.nixpkgs-fmt = {
       command = cfg.package;
-      includes = [ "*.nix" ];
+
+      inherit (cfg)
+        includes
+        excludes;
     };
   };
 }


### PR DESCRIPTION
It is as simple as the summary says.

I use `nixpkgs-fmt` in my Nix projects and the treefmt check for it generally fails in system configuration projects because of generated `hardware-configuration.nix` files not being formatted correctly, which are meant to not be modified manually.

This makes it straightforward to add exclusions, rather than having to go through `settings.formatter.nixpkgs-fmt.excludes` to do so.