### PR TITLE
google-java-format: add `aospStyle`, `includes`, `excludes`

### DIFF
--- a/programs/google-java-format.nix
+++ b/programs/google-java-format.nix
@@ -8,13 +8,38 @@ in
   options.programs.google-java-format = {
     enable = lib.mkEnableOption "google-java-format";
     package = lib.mkPackageOption pkgs "google-java-format" { };
+
+    aospStyle = lib.mkOption {
+      description = ''
+        Whether to use AOSP (Android Open Source Project) indentation.
+        In a few words, use 4-space indentation rather than the conventional
+        2-space indentation width that Google uses.
+      '';
+      type = lib.types.bool;
+      example = true;
+      default = false;
+    };
+
+    includes = lib.mkOption {
+      description = "Path/file patterns to include for google-java-format";
+      type = lib.types.listOf lib.types.str;
+      default = [ "*.java" ];
+    };
+    excludes = lib.mkOption {
+      description = "Path/file patterns to exclude for google-java-format";
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+    };
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.google-java-format = {
       command = cfg.package;
-      options = [ "--replace" ];
-      includes = [ "*.java" ];
+      options = [ "--replace" ] ++ (lib.optional cfg.aospStyle "--aosp");
+
+      inherit (cfg)
+        includes
+        excludes;
     };
   };
 }

--- a/programs/google-java-format.nix
+++ b/programs/google-java-format.nix
@@ -3,7 +3,7 @@ let
   cfg = config.programs.google-java-format;
 in
 {
-  meta.maintainers = [ ];
+  meta.maintainers = [ "sebaszv" ];
 
   options.programs.google-java-format = {
     enable = lib.mkEnableOption "google-java-format";


### PR DESCRIPTION
These are simple additions.

- `aospStyle`: For those that need 4-spaced indentation, rather than 2-spaced.
- `includes` && `excludes`: Exposed through `programs.google-java-format` rather
  than only through `settings.formatter.google-java-format`.

I also added myself to the maintainers list.
