### PR TITLE
just: fix includes config for both hidden and non-hidden justfiles

### DIFF
--- a/programs/just.nix
+++ b/programs/just.nix
@@ -23,7 +23,8 @@ in
         "--" # bash swallows the second argument when using -c
       ];
       includes = [
-        "\.?[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # 'justfile' or '.justfile', case insensitive
+        "[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # 'justfile', case insensitive
+        ".[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # '.justfile', case insensitive
       ];
     };
   };


### PR DESCRIPTION
https://github.com/numtide/treefmt-nix/pull/246 attempted to include `.justfile` files using a regex-style optional match `\.?`. However, treefmt2 uses a Glob data structure to represent include paths, not a regex. The glob library used (https://github.com/gobwas/glob) uses `?` as a single-character wildcard, meaning files matching `justfile` and `.justfile` are instead ignored.

From https://github.com/gobwas/glob/blob/master/readme.md
```
// create glob with single symbol wildcard
g = glob.MustCompile("?at")
g.Match("cat") // true
g.Match("fat") // true
g.Match("at") // false
```