### PR TITLE
treefmt config: make global settings global

### DIFF
--- a/module-options.nix
+++ b/module-options.nix
@@ -188,7 +188,6 @@ in
                   unset PRJ_ROOT
                   exec ${config.package}/bin/treefmt \
                     --config-file=${config.build.configFile} \
-                    --tree-root-file=${config.projectRootFile} \
                     "$@"
                 '';
             x = pkgs.writeShellScriptBin "treefmt" code;
@@ -275,7 +274,12 @@ in
 
   # Config
   config.build = {
-    configFile = configFormat.generate "treefmt.toml" config.settings;
+    configFile = configFormat.generate "treefmt.toml" (
+      (lib.removeAttrs config.settings [ "global" ])
+      // config.settings.global // {
+        tree-root-file = config.projectRootFile;
+      }
+    );
     devShell = pkgs.mkShell {
       nativeBuildInputs = [ config.build.wrapper ] ++ (lib.attrValues config.build.programs);
     };


### PR DESCRIPTION
Put global settings at the top level of the generated toml.

Depends on #267. Needs more work.