### PR TITLE
standardize program options with mkFormatterModule

### DIFF
--- a/examples/formatter-erlfmt.toml
+++ b/examples/formatter-erlfmt.toml
@@ -3,4 +3,4 @@
 command = "erlfmt"
 excludes = []
 includes = ["*.erl", "*.hrl", "*.app", "*.app.src", "*.config", "*.script", "*.escript"]
-options = ["--print-width", "100", "--write"]
+options = ["--write", "--print-width", "100"]

--- a/examples/formatter-rustfmt.toml
+++ b/examples/formatter-rustfmt.toml
@@ -3,4 +3,4 @@
 command = "rustfmt"
 excludes = []
 includes = ["*.rs"]
-options = ["--edition", "2021", "--config", "skip_children=true"]
+options = ["--config", "skip_children=true", "--edition", "2021"]

--- a/examples/formatter-shfmt.toml
+++ b/examples/formatter-shfmt.toml
@@ -3,4 +3,4 @@
 command = "shfmt"
 excludes = []
 includes = ["*.sh", "*.bash", "*.envrc", "*.envrc.*"]
-options = ["-i", "2", "-s", "-w"]
+options = ["-s", "-w", "-i", "2"]

--- a/programs/actionlint.nix
+++ b/programs/actionlint.nix
@@ -1,27 +1,14 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.actionlint;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.actionlint = {
-    enable = lib.mkEnableOption "actionlint";
-    package = lib.mkPackageOption pkgs "actionlint" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.actionlint = {
-      command = cfg.package;
+  imports = [
+    (mkFormatterModule {
+      name = "actionlint";
       includes = [
         ".github/workflows/*.yml"
         ".github/workflows/*.yaml"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/alejandra.nix
+++ b/programs/alejandra.nix
@@ -1,24 +1,11 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.alejandra;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.alejandra = {
-    enable = lib.mkEnableOption "alejandra";
-    package = lib.mkPackageOption pkgs "alejandra" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.alejandra = {
-      command = cfg.package;
+  imports = [
+    (mkFormatterModule {
+      name = "alejandra";
       includes = [ "*.nix" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/asmfmt.nix
+++ b/programs/asmfmt.nix
@@ -1,25 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.asmfmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.asmfmt = {
-    enable = lib.mkEnableOption "asmfmt";
-    package = lib.mkPackageOption pkgs "asmfmt" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.asmfmt = {
-      command = "${cfg.package}/bin/asmfmt";
-      options = [ "-w" ];
+  imports = [
+    (mkFormatterModule {
+      name = "asmfmt";
+      args = [ "-w" ];
       includes = [ "*.s" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/beautysh.nix
+++ b/programs/beautysh.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,9 +10,14 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "beautysh";
+      includes = [ "*.sh" ];
+    })
+  ];
+
   options.programs.beautysh = {
-    enable = lib.mkEnableOption "beautysh";
-    package = lib.mkPackageOption pkgs "beautysh" { };
     indent_size = lib.mkOption {
       type = lib.types.int;
       default = 2;
@@ -25,12 +30,10 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.beautysh = {
-      command = cfg.package;
       options = [
         "-i"
         (toString cfg.indent_size)
       ];
-      includes = [ "*.sh" ];
     };
   };
 }

--- a/programs/black.nix
+++ b/programs/black.nix
@@ -1,27 +1,14 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.black;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.black = {
-    enable = lib.mkEnableOption "black";
-    package = lib.mkPackageOption pkgs "black" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.black = {
-      command = cfg.package;
+  imports = [
+    (mkFormatterModule {
+      name = "black";
       includes = [
         "*.py"
         "*.pyi"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/buildifier.nix
+++ b/programs/buildifier.nix
@@ -1,38 +1,15 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  inherit (lib)
-    mkEnableOption
-    mkOption
-    mkPackageOption
-    types
-    ;
-  cfg = config.programs.buildifier;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.buildifier = {
-    enable = mkEnableOption "buildifier";
-    package = mkPackageOption pkgs "buildifier" { };
-    includes = mkOption {
-      description = "Bazel file patterns to format";
-      type = types.listOf types.str;
-      default = [
+  imports = [
+    (mkFormatterModule {
+      name = "buildifier";
+      mainProgram = "buildifier";
+      includes = [
         "*.bazel"
         "*.bzl"
       ];
-    };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.buildifier = {
-      command = "${cfg.package}/bin/buildifier";
-      includes = cfg.includes;
-    };
-  };
+    })
+  ];
 }

--- a/programs/cabal-fmt.nix
+++ b/programs/cabal-fmt.nix
@@ -1,32 +1,16 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.cabal-fmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.cabal-fmt = {
-    enable = lib.mkEnableOption "cabal-fmt";
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.haskellPackages.cabal-fmt;
-      defaultText = lib.literalExpression "pkgs.haskellPackages.cabal-fmt";
-      description = ''
-        cabal-fmt derivation to use.
-      '';
-    };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.cabal-fmt = {
-      command = cfg.package;
-      options = [ "--inplace" ];
+  imports = [
+    (mkFormatterModule {
+      name = "cabal-fmt";
+      package = [
+        "haskellPackages"
+        "cabal-fmt"
+      ];
+      args = [ "--inplace" ];
       includes = [ "*.cabal" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/clang-format.nix
+++ b/programs/clang-format.nix
@@ -1,24 +1,13 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.clang-format;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.clang-format = {
-    enable = lib.mkEnableOption "clang-format";
-    package = lib.mkPackageOption pkgs "clang-tools" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.clang-format = {
-      command = "${cfg.package}/bin/clang-format";
-      options = [ "-i" ];
+  imports = [
+    (mkFormatterModule {
+      name = "clang-format";
+      package = "clang-tools";
+      mainProgram = "clang-format";
+      args = [ "-i" ];
       includes = [
         "*.c"
         "*.cc"
@@ -27,6 +16,6 @@ in
         "*.hh"
         "*.hpp"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/cljfmt.nix
+++ b/programs/cljfmt.nix
@@ -1,36 +1,17 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.cljfmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.cljfmt = {
-    enable = lib.mkEnableOption "cljfmt";
-    package = lib.mkPackageOption pkgs "cljfmt" { };
-
-    includes = lib.mkOption {
-      description = "Clojure file patterns to format";
-      type = lib.types.listOf lib.types.str;
-      default = [
+  imports = [
+    (mkFormatterModule {
+      name = "cljfmt";
+      args = [ "fix" ];
+      includes = [
         "*.clj"
         "*.cljc"
         "*.cljs"
         "*.cljx"
       ];
-    };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.cljfmt = {
-      command = cfg.package;
-      options = [ "fix" ];
-      includes = cfg.includes;
-    };
-  };
+    })
+  ];
 }

--- a/programs/cmake-format.nix
+++ b/programs/cmake-format.nix
@@ -1,28 +1,15 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.cmake-format;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.cmake-format = {
-    enable = lib.mkEnableOption "cmake-format";
-    package = lib.mkPackageOption pkgs "cmake-format" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.cmake-format = {
-      command = "${cfg.package}/bin/cmake-format";
-      options = [ "--in-place" ];
+  imports = [
+    (mkFormatterModule {
+      name = "cmake-format";
+      args = [ "--in-place" ];
       includes = [
         "*.cmake"
         "CMakeLists.txt"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/csharpier.nix
+++ b/programs/csharpier.nix
@@ -2,40 +2,27 @@
   lib,
   pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
   cfg = config.programs.csharpier;
-  inherit (lib)
-    mkEnableOption
-    mkOption
-    mkPackageOption
-    mkIf
-    types
-    ;
 in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "csharpier";
+      includes = [ "*.cs" ];
+    })
+  ];
+
   options.programs.csharpier = {
-    enable = mkEnableOption "csharpier";
-    package = mkPackageOption pkgs "csharpier" { };
-    dotnet-sdk = mkPackageOption pkgs "dotnet-sdk" { };
-
-    includes = mkOption {
-      description = "Path / file patterns to include for CSharpier";
-      type = types.listOf types.str;
-      default = [ "*.cs" ];
-    };
-
-    excludes = mkOption {
-      description = "Path / file patterns to exclude for CSharpier";
-      type = types.listOf types.str;
-      default = [ ];
-    };
+    dotnet-sdk = lib.mkPackageOption pkgs "dotnet-sdk" { };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     settings.formatter.csharpier = {
       command = pkgs.writeShellApplication {
         name = "dotnet-csharpier";
@@ -47,8 +34,6 @@ in
           dotnet-csharpier "$@"
         '';
       };
-      includes = cfg.includes;
-      excludes = cfg.excludes;
     };
   };
 }

--- a/programs/cue.nix
+++ b/programs/cue.nix
@@ -1,25 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.cue;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.cue = {
-    enable = lib.mkEnableOption "cue";
-    package = lib.mkPackageOption pkgs "cue" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.cue = {
-      command = "${cfg.package}/bin/cue";
-      options = [ "fmt" ];
+  imports = [
+    (mkFormatterModule {
+      name = "cue";
+      args = [ "fmt" ];
       includes = [ "*.cue" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/d2.nix
+++ b/programs/d2.nix
@@ -1,25 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.d2;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.d2 = {
-    enable = lib.mkEnableOption "d2";
-    package = lib.mkPackageOption pkgs "d2" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.d2 = {
-      command = "${cfg.package}/bin/d2";
-      options = [ "fmt" ];
+  imports = [
+    (mkFormatterModule {
+      name = "d2";
+      args = [ "fmt" ];
       includes = [ "*.d2" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/dart-format.nix
+++ b/programs/dart-format.nix
@@ -1,25 +1,13 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.dart-format;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ "JakobLichterfeld" ];
 
-  options.programs.dart-format = {
-    enable = lib.mkEnableOption "dart-format";
-    package = lib.mkPackageOption pkgs "dart" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.dart-format = {
-      command = cfg.package;
-      options = [ "format" ];
+  imports = [
+    (mkFormatterModule {
+      name = "dart-format";
+      package = "dart";
+      args = [ "format" ];
       includes = [ "*.dart" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/deadnix.nix
+++ b/programs/deadnix.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,23 +10,24 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "deadnix";
+      args = [ "--edit" ];
+      includes = [ "*.nix" ];
+    })
+  ];
+
   options.programs.deadnix = {
-    enable = lib.mkEnableOption "deadnix";
-    package = lib.mkPackageOption pkgs "deadnix" { };
     no-lambda-arg = lib.mkEnableOption "Don't check lambda parameter arguments";
     no-lambda-pattern-names = lib.mkEnableOption "Don't check lambda attrset pattern names (don't break nixpkgs callPackage)";
     no-underscore = lib.mkEnableOption "Don't check any bindings that start with a _";
   };
 
   config = lib.mkIf cfg.enable {
-    settings.formatter.deadnix = {
-      command = cfg.package;
-      options =
-        [ "--edit" ]
-        ++ (lib.optional cfg.no-lambda-arg "--no-lambda-arg")
-        ++ (lib.optional cfg.no-lambda-pattern-names "--no-lambda-pattern-names")
-        ++ (lib.optional cfg.no-underscore "--no-underscore");
-      includes = [ "*.nix" ];
-    };
+    settings.formatter.deadnix.options =
+      (lib.optional cfg.no-lambda-arg "--no-lambda-arg")
+      ++ (lib.optional cfg.no-lambda-pattern-names "--no-lambda-pattern-names")
+      ++ (lib.optional cfg.no-underscore "--no-underscore");
   };
 }

--- a/programs/deno.nix
+++ b/programs/deno.nix
@@ -1,38 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  inherit (lib)
-    mkEnableOption
-    mkIf
-    mkOption
-    types
-    ;
-
-  cfg = config.programs.deno;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.deno = {
-    enable = mkEnableOption "deno";
-    package = mkOption {
-      type = types.package;
-      default = pkgs.deno;
-      defaultText = lib.literalExpression "pkgs.deno";
-      description = ''
-        deno derivation to use.
-      '';
-    };
-
-    # Deno-specific includes override
-    includes = mkOption {
-      description = "Path / file patterns to include for Deno";
-      type = types.listOf types.str;
-      default = [
+  imports = [
+    (mkFormatterModule {
+      name = "deno";
+      args = [ "fmt" ];
+      includes = [
         "*.css"
         "*.html"
         "*.js"
@@ -49,22 +23,6 @@ in
         "*.yaml"
         "*.yml"
       ];
-    };
-
-    # Deno-specific includes override
-    excludes = mkOption {
-      description = "Path / file patterns to exclude for Deno";
-      type = types.listOf types.str;
-      default = [ ];
-    };
-  };
-
-  config = mkIf cfg.enable {
-    settings.formatter.deno = {
-      command = cfg.package;
-      options = lib.mkBefore [ "fmt" ];
-      includes = cfg.includes;
-      excludes = cfg.excludes;
-    };
-  };
+    })
+  ];
 }

--- a/programs/dhall.nix
+++ b/programs/dhall.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,21 +10,24 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "dhall";
+      includes = [ "*.dhall" ];
+    })
+  ];
+
   options.programs.dhall = {
-    enable = lib.mkEnableOption "Dhall";
     lint = lib.mkOption {
       type = lib.types.bool;
       default = false;
       description = "Whether to lint in addition to formatting.";
     };
-    package = lib.mkPackageOption pkgs "Dhall" { default = [ "dhall" ]; };
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.dhall = {
-      command = cfg.package;
       options = [ (if cfg.lint then "lint" else "format") ];
-      includes = [ "*.dhall" ];
     };
   };
 }

--- a/programs/dnscontrol.nix
+++ b/programs/dnscontrol.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,20 +11,21 @@ in
 {
   meta.maintainers = [ ];
 
-  options.programs.dnscontrol = {
-    enable = lib.mkEnableOption "dnscontrol";
-    package = lib.mkPackageOption pkgs "dnscontrol" { };
-  };
+  imports = [
+    (mkFormatterModule {
+      name = "dnscontrol";
+      includes = [ "dnsconfig.js" ];
+    })
+  ];
 
   config = lib.mkIf cfg.enable {
     settings.formatter.dnscontrol = {
       # dnscontrol doesn't support multiple file targets
       command = pkgs.writeShellScriptBin "dnscontrol-fix" ''
-        for file in "''$@"; do
+        for file in "$@"; do
           ${lib.getExe cfg.package} fmt -i "$file" -o "$file"
         done
       '';
-      includes = [ "dnsconfig.js" ];
     };
   };
 }

--- a/programs/dos2unix.nix
+++ b/programs/dos2unix.nix
@@ -1,25 +1,15 @@
 {
-  lib,
-  pkgs,
-  config,
+  mkFormatterModule,
   ...
 }:
-let
-  cfg = config.programs.dos2unix;
-in
 {
   meta.maintainers = [ ];
 
-  options.programs.dos2unix = {
-    enable = lib.mkEnableOption "dos2unix";
-    package = lib.mkPackageOption pkgs "dos2unix" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.dos2unix = {
-      command = "${cfg.package}/bin/dos2unix";
-      options = [ "--keepdate" ];
+  imports = [
+    (mkFormatterModule {
+      name = "dos2unix";
+      args = [ "--keepdate" ];
       includes = [ "*" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/elm-format.nix
+++ b/programs/elm-format.nix
@@ -1,40 +1,16 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.elm-format;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.elm-format = {
-    enable = lib.mkEnableOption "elm-format";
-
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.elmPackages.elm-format;
-      defaultText = lib.literalExpression "pkgs.elmPackages.elm-format";
-      description = ''
-        elm-format derivation to use.
-      '';
-    };
-
-    includes = lib.mkOption {
-      description = "Path / file patterns to include for elm-format";
-      type = lib.types.listOf lib.types.str;
-      example = [ "*.elm" ];
-      default = [ "*.elm" ];
-    };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.elm-format = {
-      command = cfg.package;
-      options = [ "--yes" ];
-      inherit (cfg) includes;
-    };
-  };
+  imports = [
+    (mkFormatterModule {
+      name = "elm-format";
+      package = [
+        "elmPackages"
+        "elm-format"
+      ];
+      args = [ "--yes" ];
+      includes = [ "*.elm" ];
+    })
+  ];
 }

--- a/programs/erlfmt.nix
+++ b/programs/erlfmt.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,9 +10,23 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "erlfmt";
+      args = [ "--write" ];
+      includes = [
+        "*.erl"
+        "*.hrl"
+        "*.app"
+        "*.app.src"
+        "*.config"
+        "*.script"
+        "*.escript"
+      ];
+    })
+  ];
+
   options.programs.erlfmt = {
-    enable = lib.mkEnableOption "erlfmt";
-    package = lib.mkPackageOption pkgs "erlfmt" { };
     print-width = lib.mkOption {
       description = "The line length that formatter would wrap on";
       type = lib.types.int;
@@ -23,20 +37,9 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.erlfmt = {
-      command = "${cfg.package}/bin/erlfmt";
       options = [
         "--print-width"
         (toString cfg.print-width)
-        "--write"
-      ];
-      includes = [
-        "*.erl"
-        "*.hrl"
-        "*.app"
-        "*.app.src"
-        "*.config"
-        "*.script"
-        "*.escript"
       ];
     };
   };

--- a/programs/fantomas.nix
+++ b/programs/fantomas.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,9 +11,21 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "fantomas";
+      args = [ "--inputs" ];
+      includes = [
+        "*.fs"
+        "*.fsx"
+        "*.fsi"
+        "*.ml"
+        "*.mli"
+      ];
+    })
+  ];
+
   options.programs.fantomas = {
-    enable = lib.mkEnableOption "fantomas";
-    package = lib.mkPackageOption pkgs "fantomas" { };
     dotnet-sdk = lib.mkPackageOption pkgs "dotnet-sdk" { };
   };
 
@@ -28,13 +41,6 @@ in
           fantomas "$@"
         '';
       };
-      includes = [
-        "*.fs"
-        "*.fsx"
-        "*.fsi"
-        "*.ml"
-        "*.mli"
-      ];
     };
   };
 }

--- a/programs/fish_indent.nix
+++ b/programs/fish_indent.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,10 +11,13 @@ in
 {
   meta.maintainers = [ ];
 
-  options.programs.fish_indent = {
-    enable = lib.mkEnableOption "fish_indent";
-    package = lib.mkPackageOption pkgs "fish" { };
-  };
+  imports = [
+    (mkFormatterModule {
+      name = "fish_indent";
+      package = "fish";
+      includes = [ "*.fish" ];
+    })
+  ];
 
   config = lib.mkIf cfg.enable {
     settings.formatter.fish_indent = {
@@ -27,7 +31,6 @@ in
           fish_indent --check "$@" 2>&1 | xargs --no-run-if-empty fish_indent --write || true
         '';
       };
-      includes = [ "*.fish" ];
     };
   };
 }

--- a/programs/fnlfmt.nix
+++ b/programs/fnlfmt.nix
@@ -1,25 +1,15 @@
 {
-  lib,
-  pkgs,
-  config,
+  mkFormatterModule,
   ...
 }:
-let
-  cfg = config.programs.fnlfmt;
-in
 {
   meta.maintainers = [ ];
 
-  options.programs.fnlfmt = {
-    enable = lib.mkEnableOption "fnlfmt";
-    package = lib.mkPackageOption pkgs "fnlfmt" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.fnlfmt = {
-      command = cfg.package;
-      options = [ "--fix" ];
+  imports = [
+    (mkFormatterModule {
+      name = "fnlfmt";
+      args = [ "--fix" ];
       includes = [ "*.fnl" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/formatjson5.nix
+++ b/programs/formatjson5.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,9 +10,15 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "formatjson5";
+      args = [ "--replace" ];
+      includes = [ "*.json5" ];
+    })
+  ];
+
   options.programs.formatjson5 = {
-    enable = lib.mkEnableOption "formatjson5";
-    package = lib.mkPackageOption pkgs "formatjson5" { };
     noTrailingCommas = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -37,16 +43,13 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.formatjson5 = {
-      command = cfg.package;
       options =
         [
-          "--replace"
           "--indent=${toString cfg.indent}"
         ]
         ++ lib.optional cfg.noTrailingCommas "--no_trailing_commas"
         ++ lib.optional cfg.oneElementLines "--one_element_lines"
         ++ lib.optional cfg.sortArrays "--sort_arrays";
-      includes = [ "*.json5" ];
     };
   };
 }

--- a/programs/fourmolu.nix
+++ b/programs/fourmolu.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,16 +10,22 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "fourmolu";
+      package = [
+        "haskellPackages"
+        "fourmolu"
+      ];
+      args = [
+        "-i"
+        "-c"
+      ];
+      includes = [ "*.hs" ];
+    })
+  ];
+
   options.programs.fourmolu = {
-    enable = lib.mkEnableOption "fourmolu";
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.haskellPackages.fourmolu;
-      defaultText = lib.literalExpression "pkgs.haskellPackages.fourmolu";
-      description = ''
-        fourmolu derivation to use.
-      '';
-    };
     ghcOpts = lib.mkOption {
       description = "Which GHC language extensions to enable";
       default = [
@@ -32,17 +38,10 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.fourmolu = {
-      command = cfg.package;
-      options =
-        [
-          "-i"
-          "-c"
-        ]
-        ++ (lib.concatMap (x: [
-          "--ghc-opt"
-          "-X${x}"
-        ]) cfg.ghcOpts);
-      includes = [ "*.hs" ];
+      options = lib.concatMap (x: [
+        "--ghc-opt"
+        "-X${x}"
+      ]) cfg.ghcOpts;
     };
   };
 }

--- a/programs/fprettify.nix
+++ b/programs/fprettify.nix
@@ -1,24 +1,11 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.fprettify;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.fprettify = {
-    enable = lib.mkEnableOption "fprettify";
-    package = lib.mkPackageOption pkgs "fprettify" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.fprettify = {
-      command = "${cfg.package}/bin/fprettify";
+  imports = [
+    (mkFormatterModule {
+      name = "fprettify";
       includes = [ "*.f90" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/gdformat.nix
+++ b/programs/gdformat.nix
@@ -1,24 +1,13 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.gdformat;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.gdformat = {
-    enable = lib.mkEnableOption "gdformat";
-    package = lib.mkPackageOption pkgs "gdtoolkit_4" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.gdformat = {
-      command = "${cfg.package}/bin/gdformat";
+  imports = [
+    (mkFormatterModule {
+      name = "gdformat";
+      package = "gdtoolkit_4";
+      mainProgram = "gdformat";
       includes = [ "*.gd" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/gleam.nix
+++ b/programs/gleam.nix
@@ -1,25 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.gleam;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ "anntnzrb" ];
 
-  options.programs.gleam = {
-    enable = lib.mkEnableOption "gleam";
-    package = lib.mkPackageOption pkgs "gleam" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.gleam = {
-      command = cfg.package;
-      options = [ "format" ];
+  imports = [
+    (mkFormatterModule {
+      name = "gleam";
+      args = [ "format" ];
       includes = [ "*.gleam" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/gofmt.nix
+++ b/programs/gofmt.nix
@@ -1,7 +1,7 @@
 {
-  lib,
-  pkgs,
   config,
+  lib,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,17 +10,20 @@ in
 {
   meta.maintainers = [ "zimbatm" ];
 
-  options.programs.gofmt = {
-    enable = lib.mkEnableOption "gofmt";
-    package = lib.mkPackageOption pkgs "go" { };
-  };
+  imports = [
+    (mkFormatterModule {
+      name = "gofmt";
+      # It would be nice to extract gofmt to its own package
+      package = "go";
+      args = [ "-w" ];
+      includes = [ "*.go" ];
+      excludes = [ "vendor/*" ];
+    })
+  ];
 
   config = lib.mkIf cfg.enable {
     settings.formatter.gofmt = {
       command = "${cfg.package}/bin/gofmt";
-      options = [ "-w" ];
-      includes = [ "*.go" ];
-      excludes = [ "vendor/*" ];
     };
   };
 }

--- a/programs/gofumpt.nix
+++ b/programs/gofumpt.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,9 +10,16 @@ in
 {
   meta.maintainers = [ "zimbatm" ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "gofumpt";
+      args = [ "-w" ];
+      includes = [ "*.go" ];
+      excludes = [ "vendor/*" ];
+    })
+  ];
+
   options.programs.gofumpt = {
-    enable = lib.mkEnableOption "gofumpt";
-    package = lib.mkPackageOption pkgs "gofumpt" { };
     extra = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -24,10 +31,7 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.gofumpt = {
-      command = cfg.package;
-      options = [ "-w" ] ++ lib.optional cfg.extra "-extra";
-      includes = [ "*.go" ];
-      excludes = [ "vendor/*" ];
+      options = lib.optional cfg.extra "-extra";
     };
   };
 }

--- a/programs/goimports.nix
+++ b/programs/goimports.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,17 +10,19 @@ in
 {
   meta.maintainers = [ "gabyx" ];
 
-  options.programs.goimports = {
-    enable = lib.mkEnableOption "goimports";
-    package = lib.mkPackageOption pkgs "gotools" { };
-  };
+  imports = [
+    (mkFormatterModule {
+      name = "goimports";
+      package = "gotools";
+      args = [ "-w" ];
+      includes = [ "*.go" ];
+      excludes = [ "vendor/*" ];
+    })
+  ];
 
   config = lib.mkIf cfg.enable {
     settings.formatter.goimports = {
       command = "${cfg.package}/bin/goimports";
-      options = [ "-w" ];
-      includes = [ "*.go" ];
-      excludes = [ "vendor/*" ];
     };
   };
 }

--- a/programs/google-java-format.nix
+++ b/programs/google-java-format.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,10 +10,15 @@ in
 {
   meta.maintainers = [ "sebaszv" ];
 
-  options.programs.google-java-format = {
-    enable = lib.mkEnableOption "google-java-format";
-    package = lib.mkPackageOption pkgs "google-java-format" { };
+  imports = [
+    (mkFormatterModule {
+      name = "google-java-format";
+      args = [ "--replace" ];
+      includes = [ "*.java" ];
+    })
+  ];
 
+  options.programs.google-java-format = {
     aospStyle = lib.mkOption {
       description = ''
         Whether to use AOSP (Android Open Source Project) indentation.
@@ -24,28 +29,9 @@ in
       example = true;
       default = false;
     };
-
-    includes = lib.mkOption {
-      description = "Path/file patterns to include for google-java-format";
-      type = lib.types.listOf lib.types.str;
-      default = [ "*.java" ];
-    };
-    excludes = lib.mkOption {
-      description = "Path/file patterns to exclude for google-java-format";
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-    };
   };
 
   config = lib.mkIf cfg.enable {
-    settings.formatter.google-java-format = {
-      command = cfg.package;
-      options = [ "--replace" ] ++ (lib.optional cfg.aospStyle "--aosp");
-
-      inherit (cfg)
-        includes
-        excludes
-        ;
-    };
+    settings.formatter.google-java-format.options = lib.optional cfg.aospStyle "--aosp";
   };
 }

--- a/programs/hclfmt.nix
+++ b/programs/hclfmt.nix
@@ -1,30 +1,13 @@
 # NOTE: this is the hclfmt that comes from hashicorp/hcl
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.hclfmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ "zimbatm" ];
 
-  options.programs.hclfmt = {
-    enable = lib.mkEnableOption "hclfmt";
-    package = lib.mkPackageOption pkgs "hclfmt" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.hclfmt = {
-      command = cfg.package;
-      options = [
-        "-w" # write in place
-      ];
-      includes = [
-        "*.hcl"
-      ];
-    };
-  };
+  imports = [
+    (mkFormatterModule {
+      name = "hclfmt";
+      args = [ "-w" ];
+      includes = [ "*.hcl" ];
+    })
+  ];
 }

--- a/programs/hlint.nix
+++ b/programs/hlint.nix
@@ -1,25 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.hlint;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.hlint = {
-    enable = lib.mkEnableOption "hlint";
-    package = lib.mkPackageOption pkgs "hlint" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.hlint = {
-      command = cfg.package;
-      options = [ "-j" ];
+  imports = [
+    (mkFormatterModule {
+      name = "hlint";
+      args = [ "-j" ];
       includes = [ "*.hs" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/isort.nix
+++ b/programs/isort.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,9 +10,17 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "isort";
+      includes = [
+        "*.py"
+        "*.pyi"
+      ];
+    })
+  ];
+
   options.programs.isort = {
-    enable = lib.mkEnableOption "isort";
-    package = lib.mkPackageOption pkgs "isort" { };
     profile = lib.mkOption {
       type = lib.types.str;
       default = "";
@@ -23,20 +31,9 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    settings.formatter.isort = {
-      command = cfg.package;
-      options =
-        if cfg.profile != "" then
-          [
-            "--profile"
-            cfg.profile
-          ]
-        else
-          [ ];
-      includes = [
-        "*.py"
-        "*.pyi"
-      ];
-    };
+    settings.formatter.isort.options = lib.optionals (cfg.profile != "") [
+      "--profile"
+      cfg.profile
+    ];
   };
 }

--- a/programs/jsonfmt.nix
+++ b/programs/jsonfmt.nix
@@ -1,25 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.jsonfmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.jsonfmt = {
-    enable = lib.mkEnableOption "jsonfmt";
-    package = lib.mkPackageOption pkgs "jsonfmt" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.jsonfmt = {
-      command = cfg.package;
+  imports = [
+    (mkFormatterModule {
+      name = "jsonfmt";
+      args = [ "-w" ];
       includes = [ "*.json" ];
-      options = [ "-w" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/jsonnet-lint.nix
+++ b/programs/jsonnet-lint.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,18 +10,20 @@ in
 {
   meta.maintainers = [ ];
 
-  options.programs.jsonnet-lint = {
-    enable = lib.mkEnableOption "jsonnet";
-    package = lib.mkPackageOption pkgs "go-jsonnet" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.jsonnet-lint = {
-      command = "${cfg.package}/bin/jsonnet-lint";
+  imports = [
+    (mkFormatterModule {
+      name = "jsonnet-lint";
+      package = "go-jsonnet";
       includes = [
         "*.jsonnet"
         "*.libsonnet"
       ];
+    })
+  ];
+
+  config = lib.mkIf cfg.enable {
+    settings.formatter.jsonnet-lint = {
+      command = "${cfg.package}/bin/jsonnet-lint";
     };
   };
 }

--- a/programs/jsonnetfmt.nix
+++ b/programs/jsonnetfmt.nix
@@ -1,28 +1,17 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.jsonnetfmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.jsonnetfmt = {
-    enable = lib.mkEnableOption "jsonnet";
-    package = lib.mkPackageOption pkgs "go-jsonnet" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.jsonnetfmt = {
-      command = "${cfg.package}/bin/jsonnetfmt";
-      options = [ "-i" ];
+  imports = [
+    (mkFormatterModule {
+      name = "jsonnetfmt";
+      package = "go-jsonnet";
+      mainProgram = "jsonnetfmt";
+      args = [ "-i" ];
       includes = [
         "*.jsonnet"
         "*.libsonnet"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/just.nix
+++ b/programs/just.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,10 +11,15 @@ in
 {
   meta.maintainers = [ ];
 
-  options.programs.just = {
-    enable = lib.mkEnableOption "just";
-    package = lib.mkPackageOption pkgs "just" { };
-  };
+  imports = [
+    (mkFormatterModule {
+      name = "just";
+      includes = [
+        "[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # 'justfile', case insensitive
+        ".[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # '.justfile', case insensitive
+      ];
+    })
+  ];
 
   config = lib.mkIf cfg.enable {
     settings.formatter.just = {
@@ -26,10 +32,6 @@ in
           done
         ''
         "--" # bash swallows the second argument when using -c
-      ];
-      includes = [
-        "[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # 'justfile', case insensitive
-        ".[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # '.justfile', case insensitive
       ];
     };
   };

--- a/programs/keep-sorted.nix
+++ b/programs/keep-sorted.nix
@@ -1,24 +1,11 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.keep-sorted;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.keep-sorted = {
-    enable = lib.mkEnableOption "keep-sorted";
-    package = lib.mkPackageOption pkgs "keep-sorted" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.keep-sorted = {
-      command = cfg.package;
+  imports = [
+    (mkFormatterModule {
+      name = "keep-sorted";
       includes = [ "*" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/ktfmt.nix
+++ b/programs/ktfmt.nix
@@ -1,27 +1,14 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.ktfmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.ktfmt = {
-    enable = lib.mkEnableOption "ktfmt";
-    package = lib.mkPackageOption pkgs "ktfmt" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.ktfmt = {
-      command = cfg.package;
+  imports = [
+    (mkFormatterModule {
+      name = "ktfmt";
       includes = [
         "*.kt"
         "*.kts"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/ktlint.nix
+++ b/programs/ktlint.nix
@@ -1,28 +1,15 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.ktlint;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.ktlint = {
-    enable = lib.mkEnableOption "ktlint";
-    package = lib.mkPackageOption pkgs "ktlint" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.ktlint = {
-      command = cfg.package;
-      options = [ "--format" ];
+  imports = [
+    (mkFormatterModule {
+      name = "ktlint";
+      args = [ "--format" ];
       includes = [
         "*.kt"
         "*.kts"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/latexindent.nix
+++ b/programs/latexindent.nix
@@ -1,24 +1,16 @@
 {
-  lib,
-  pkgs,
-  config,
+  mkFormatterModule,
   ...
 }:
-let
-  cfg = config.programs.latexindent;
-in
 {
   meta.maintainers = [ ];
 
-  options.programs.latexindent = {
-    enable = lib.mkEnableOption "latexindent";
-    package = lib.mkPackageOption pkgs "texliveMedium" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.latexindent = {
-      command = lib.getExe' cfg.package "latexindent";
-      options = [ "-wd" ];
+  imports = [
+    (mkFormatterModule {
+      name = "latexindent";
+      package = "texliveMedium";
+      mainProgram = "latexindent";
+      args = [ "-wd" ];
       includes = [
         "*.tex"
         "*.sty"
@@ -26,6 +18,6 @@ in
         "*.bib"
         "*.cmh"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/leptosfmt.nix
+++ b/programs/leptosfmt.nix
@@ -1,24 +1,11 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.leptosfmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.leptosfmt = {
-    enable = lib.mkEnableOption "leptosfmt";
-    package = lib.mkPackageOption pkgs "leptosfmt" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.leptosfmt = {
-      command = "${cfg.package}/bin/leptosfmt";
+  imports = [
+    (mkFormatterModule {
+      name = "leptosfmt";
       includes = [ "*.rs" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/mdformat.nix
+++ b/programs/mdformat.nix
@@ -1,24 +1,15 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.mdformat;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.mdformat = {
-    enable = lib.mkEnableOption "mdformat";
-    package = lib.mkPackageOption pkgs [ "python3Packages" "mdformat" ] { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.mdformat = {
-      command = cfg.package;
+  imports = [
+    (mkFormatterModule {
+      name = "mdformat";
+      package = [
+        "python3Packages"
+        "mdformat"
+      ];
       includes = [ "*.md" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/mdsh.nix
+++ b/programs/mdsh.nix
@@ -1,25 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.mdsh;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ "zimbatm" ];
 
-  options.programs.mdsh = {
-    enable = lib.mkEnableOption "mdsh";
-    package = lib.mkPackageOption pkgs "mdsh" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.mdsh = {
-      command = cfg.package;
-      options = [ "--inputs" ];
+  imports = [
+    (mkFormatterModule {
+      name = "mdsh";
+      args = [ "--inputs" ];
       includes = [ "README.md" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/meson.nix
+++ b/programs/meson.nix
@@ -1,24 +1,11 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.meson;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ "RossSmyth" ];
 
-  options.programs.meson = {
-    enable = lib.mkEnableOption "meson";
-    package = lib.mkPackageOption pkgs "meson" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.meson = {
-      command = cfg.package;
-      options = [
+  imports = [
+    (mkFormatterModule {
+      name = "meson";
+      args = [
         "fmt"
         "-i"
       ];
@@ -30,6 +17,6 @@ in
         "*/meson.options"
         "*/meson_options.txt"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/mix-format.nix
+++ b/programs/mix-format.nix
@@ -1,28 +1,17 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.mix-format;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.mix-format = {
-    enable = lib.mkEnableOption "mix-format";
-    package = lib.mkPackageOption pkgs "elixir" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.mix-format = {
-      command = "${cfg.package}/bin/mix";
-      options = [ "format" ];
+  imports = [
+    (mkFormatterModule {
+      name = "mix-format";
+      package = "elixir";
+      mainProgram = "mix";
+      args = [ "format" ];
       includes = [
         "*.ex"
         "*.exs"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/muon.nix
+++ b/programs/muon.nix
@@ -1,24 +1,11 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.muon;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.muon = {
-    enable = lib.mkEnableOption "muon";
-    package = lib.mkPackageOption pkgs "muon" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.muon = {
-      command = cfg.package;
-      options = [
+  imports = [
+    (mkFormatterModule {
+      name = "muon";
+      args = [
         "fmt"
         "-i"
       ];
@@ -30,6 +17,6 @@ in
         "*/meson.options"
         "*/meson_options.txt"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/mypy.nix
+++ b/programs/mypy.nix
@@ -28,7 +28,7 @@ in
               extraPythonPackages = lib.mkOption {
                 type = lib.types.listOf lib.types.package;
                 default = [ ];
-                example = lib.literalMD ''[ pkgs.python3.pkgs.requests ]'';
+                example = lib.literalMD "[ pkgs.python3.pkgs.requests ]";
                 description = "Extra packages to add to PYTHONPATH";
               };
               extraPythonPaths = lib.mkOption {

--- a/programs/nickel.nix
+++ b/programs/nickel.nix
@@ -1,28 +1,15 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.nickel;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.nickel = {
-    enable = lib.mkEnableOption "nickel";
-    package = lib.mkPackageOption pkgs "nickel" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.nickel = {
-      command = cfg.package;
-      options = [ "format" ];
+  imports = [
+    (mkFormatterModule {
+      name = "nickel";
+      args = [ "format" ];
       includes = [
         "*.ncl"
         "*.nickel"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/nimpretty.nix
+++ b/programs/nimpretty.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,15 +10,17 @@ in
 {
   meta.maintainers = [ ];
 
-  options.programs.nimpretty = {
-    enable = lib.mkEnableOption "nimpretty";
-    package = lib.mkPackageOption pkgs "nim" { };
-  };
+  imports = [
+    (mkFormatterModule {
+      name = "nimpretty";
+      package = "nim";
+      includes = [ "*.nim" ];
+    })
+  ];
 
   config = lib.mkIf cfg.enable {
     settings.formatter.nimpretty = {
       command = "${cfg.package}/bin/nimpretty";
-      includes = [ "*.nim" ];
     };
   };
 }

--- a/programs/nixfmt-classic.nix
+++ b/programs/nixfmt-classic.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,25 +10,22 @@ in
 {
   meta.maintainers = [ ];
 
-  options.programs.nixfmt-classic = {
-    enable = lib.mkEnableOption "nixfmt-classic";
-    package = lib.mkPackageOption pkgs "nixfmt-classic" { };
-  };
+  imports = [
+    (mkFormatterModule {
+      name = "nixfmt-classic";
+      includes = [ "*.nix" ];
+    })
+  ];
 
   config = lib.mkIf cfg.enable {
     settings.formatter.nixfmt-classic = (
-      lib.warn
-        ''
-          nixfmt-classic is the original flavor of 'nixfmt'.
-          This version differs considerably from the new standard and is currently
-          unmaintained.
-          It has been superseded by 'nixfmt', which conforms to the
-          'nixfmt-rfc-style' standard.
-        ''
-        {
-          command = cfg.package;
-          includes = [ "*.nix" ];
-        }
+      lib.warn ''
+        nixfmt-classic is the original flavor of 'nixfmt'.
+        This version differs considerably from the new standard and is currently
+        unmaintained.
+        It has been superseded by 'nixfmt', which conforms to the
+        'nixfmt-rfc-style' standard.
+      '' { }
     );
   };
 }

--- a/programs/nixfmt-rfc-style.nix
+++ b/programs/nixfmt-rfc-style.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,22 +10,19 @@ in
 {
   meta.maintainers = [ ];
 
-  options.programs.nixfmt-rfc-style = {
-    enable = lib.mkEnableOption "nixfmt-rfc-style";
-    package = lib.mkPackageOption pkgs "nixfmt-rfc-style" { };
-  };
+  imports = [
+    (mkFormatterModule {
+      name = "nixfmt-rfc-style";
+      includes = [ "*.nix" ];
+    })
+  ];
 
   config = lib.mkIf cfg.enable {
     settings.formatter.nixfmt-rfc-style = (
-      lib.warn
-        ''
-           nixfmt-rfc-style is now the default for the 'nixfmt' formatter.
-          'nixfmt-rfc-style' is deprecated and will be removed in the future.
-        ''
-        {
-          command = cfg.package;
-          includes = [ "*.nix" ];
-        }
+      lib.warn ''
+         nixfmt-rfc-style is now the default for the 'nixfmt' formatter.
+        'nixfmt-rfc-style' is deprecated and will be removed in the future.
+      '' { }
     );
   };
 }

--- a/programs/nixfmt.nix
+++ b/programs/nixfmt.nix
@@ -1,24 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.nixfmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.nixfmt = {
-    enable = lib.mkEnableOption "nixfmt";
-    package = lib.mkPackageOption pkgs "nixfmt-rfc-style" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.nixfmt = {
-      command = cfg.package;
+  imports = [
+    (mkFormatterModule {
+      name = "nixfmt";
+      package = "nixfmt-rfc-style";
       includes = [ "*.nix" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/nixpkgs-fmt.nix
+++ b/programs/nixpkgs-fmt.nix
@@ -1,39 +1,11 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.nixpkgs-fmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ "zimbatm" ];
 
-  options.programs.nixpkgs-fmt = {
-    enable = lib.mkEnableOption "nixpkgs-fmt";
-    package = lib.mkPackageOption pkgs "nixpkgs-fmt" { };
-
-    includes = lib.mkOption {
-      description = "Path/file patterns to include for nixpkgs-fmt";
-      type = lib.types.listOf lib.types.str;
-      default = [ "*.nix" ];
-    };
-    excludes = lib.mkOption {
-      description = "Path/file patterns to exclude for nixpkgs-fmt";
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-    };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.nixpkgs-fmt = {
-      command = cfg.package;
-
-      inherit (cfg)
-        includes
-        excludes
-        ;
-    };
-  };
+  imports = [
+    (mkFormatterModule {
+      name = "nixpkgs-fmt";
+      includes = [ "*.nix" ];
+    })
+  ];
 }

--- a/programs/nufmt.nix
+++ b/programs/nufmt.nix
@@ -1,26 +1,11 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.nufmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.nufmt = {
-    enable = lib.mkEnableOption "nufmt";
-    package = lib.mkPackageOption pkgs "nufmt" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.nufmt = {
-      command = "${cfg.package}/bin/nufmt";
-      includes = [
-        "*.nu"
-      ];
-    };
-  };
+  imports = [
+    (mkFormatterModule {
+      name = "nufmt";
+      includes = [ "*.nu" ];
+    })
+  ];
 }

--- a/programs/opa.nix
+++ b/programs/opa.nix
@@ -1,28 +1,16 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.opa;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.opa = {
-    enable = lib.mkEnableOption "opa";
-    package = lib.mkPackageOption pkgs "open-policy-agent" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.opa = {
-      command = cfg.package;
-      options = [
+  imports = [
+    (mkFormatterModule {
+      name = "opa";
+      package = "open-policy-agent";
+      args = [
         "fmt"
         "-w"
       ];
       includes = [ "*.rego" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/ormolu.nix
+++ b/programs/ormolu.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,9 +10,19 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "ormolu";
+      args = [
+        "--mode"
+        "inplace"
+        "--check-idempotence"
+      ];
+      includes = [ "*.hs" ];
+    })
+  ];
+
   options.programs.ormolu = {
-    enable = lib.mkEnableOption "ormolu";
-    package = lib.mkPackageOption pkgs "ormolu" { };
     ghcOpts = lib.mkOption {
       description = "Which GHC language extensions to enable";
       default = [
@@ -25,18 +35,12 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.ormolu = {
-      command = cfg.package;
-      options =
-        [
-          "--mode"
-          "inplace"
-          "--check-idempotence"
-        ]
-        ++ (lib.concatMap (x: [
+      options = (
+        lib.concatMap (x: [
           "--ghc-opt"
           "-X${x}"
-        ]) cfg.ghcOpts);
-      includes = [ "*.hs" ];
+        ]) cfg.ghcOpts
+      );
     };
   };
 }

--- a/programs/packer.nix
+++ b/programs/packer.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -53,19 +54,20 @@ in
 {
   meta.maintainers = [ ];
 
-  options.programs.packer = {
-    enable = lib.mkEnableOption "packer";
-    package = lib.mkPackageOption pkgs "packer" { };
-  };
+  imports = [
+    (mkFormatterModule {
+      name = "packer";
+      includes = [
+        "*.pkr.hcl"
+        "*.pkrvars.hcl"
+      ];
+    })
+  ];
 
   config = lib.mkIf cfg.enable {
     settings.formatter.packer = {
       inherit command;
       options = lib.mkAfter [ "--" ];
-      includes = [
-        "*.pkr.hcl"
-        "*.pkrvars.hcl"
-      ];
     };
   };
 }

--- a/programs/perltidy.nix
+++ b/programs/perltidy.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,47 +10,32 @@ in
 {
   meta.maintainers = [ "haruki7049" ];
 
-  options.programs.perltidy = {
-    enable = lib.mkEnableOption "perltidy";
-    package = lib.mkPackageOption pkgs.perlPackages "PerlTidy" { };
-
-    options = lib.mkOption {
-      description = "Options for perltidy";
-      type = lib.types.listOf lib.types.str;
-      default = [
+  imports = [
+    (mkFormatterModule {
+      name = "perltidy";
+      package = [
+        "perlPackages"
+        "PerlTidy"
+      ];
+      args = [
         "-b"
         "-bext='/'"
       ];
-    };
+      includes = [ "*.pl" ];
+    })
+  ];
 
+  options.programs.perltidy = {
     perltidyrc = lib.mkOption {
       description = "A path for perltidy's configuration file, usually named .perltidyrc";
       type = lib.types.nullOr lib.types.path;
       default = null;
     };
-
-    includes = lib.mkOption {
-      description = "Path/file patterns to include for perltidy";
-      type = lib.types.listOf lib.types.str;
-      default = [ "*.pl" ];
-    };
-    excludes = lib.mkOption {
-      description = "Path/file patterns to exclude for perltidy";
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-    };
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.perltidy = {
-      command = cfg.package;
-
-      options = lib.optional (cfg.perltidyrc != null) "-pro=${cfg.perltidyrc}" ++ cfg.options;
-
-      inherit (cfg)
-        includes
-        excludes
-        ;
+      options = lib.optional (cfg.perltidyrc != null) "-pro=${cfg.perltidyrc}";
     };
   };
 }

--- a/programs/php-cs-fixer.nix
+++ b/programs/php-cs-fixer.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -11,9 +11,19 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "php-cs-fixer";
+      package = [
+        "phpPackages"
+        "php-cs-fixer"
+      ];
+      args = [ "fix" ];
+      includes = [ "*.php" ];
+    })
+  ];
+
   options.programs.php-cs-fixer = {
-    enable = lib.mkEnableOption "php-cs-fixer";
-    package = lib.mkPackageOption pkgs.phpPackages "php-cs-fixer" { };
     configFile = lib.mkOption {
       description = "Path to php-cs-fixer config file.";
       type = types.oneOf [
@@ -27,13 +37,10 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.php-cs-fixer = {
-      command = "${cfg.package}/bin/php-cs-fixer";
       options = [
-        "fix"
         "--config"
         "${cfg.configFile}"
       ];
-      includes = [ "*.php" ];
     };
   };
 }

--- a/programs/protolint.nix
+++ b/programs/protolint.nix
@@ -1,28 +1,15 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.protolint;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.protolint = {
-    enable = lib.mkEnableOption "protolint";
-    package = lib.mkPackageOption pkgs "protolint" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.protolint = {
-      command = cfg.package;
-      options = [
+  imports = [
+    (mkFormatterModule {
+      name = "protolint";
+      args = [
         "lint"
         "-fix"
       ];
       includes = [ "*.proto" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/purs-tidy.nix
+++ b/programs/purs-tidy.nix
@@ -1,35 +1,19 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.purs-tidy;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.purs-tidy = {
-    enable = lib.mkEnableOption "purs-tidy";
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.nodePackages.purs-tidy;
-      defaultText = lib.literalExpression "pkgs.nodePackages.purs-tidy";
-      description = ''
-        purs-tidy derivation to use.
-      '';
-    };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.purs-tidy = {
-      command = cfg.package;
-      options = [ "format-in-place" ];
+  imports = [
+    (mkFormatterModule {
+      name = "purs-tidy";
+      package = [
+        "nodePackages"
+        "purs-tidy"
+      ];
+      args = [ "format-in-place" ];
       includes = [
         "src/**/*.purs"
         "test/**/*.purs"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/rubocop.nix
+++ b/programs/rubocop.nix
@@ -1,24 +1,11 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.rubocop;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.rubocop = {
-    enable = lib.mkEnableOption "rubocop";
-    package = lib.mkPackageOption pkgs "rubocop" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.rubocop = {
-      command = cfg.package;
+  imports = [
+    (mkFormatterModule {
+      name = "rubocop";
       includes = [ "*.rb" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/ruff-check.nix
+++ b/programs/ruff-check.nix
@@ -1,36 +1,28 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.ruff-check;
-in
+{ lib, mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
   imports = [
-    (lib.mkRenamedOptionModule [ "programs" "ruff" "check" ] [ "programs" "ruff-check" "enable" ])
-    (lib.mkRenamedOptionModule [ "programs" "ruff" "enable" ] [ "programs" "ruff-check" "enable" ])
-  ];
-
-  options.programs.ruff-check = {
-    enable = lib.mkEnableOption "ruff linter" // {
-      description = ''
-        Whether to enable the Ruff linter, an extremely fast Python linter
-        designed as a drop-in replacement for Flake8 (plus dozens of plugins),
-        isort, pydocstyle, pyupgrade, autoflake, and more.
-      '';
-    };
-
-    package = lib.mkPackageOption pkgs "ruff" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.ruff-check = {
-      command = cfg.package;
-      options = lib.mkBefore [
+    (lib.mkRenamedOptionModule
+      [ "programs" "ruff" "check" ]
+      [
+        "programs"
+        "ruff-check"
+        "enable"
+      ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "programs" "ruff" "enable" ]
+      [
+        "programs"
+        "ruff-check"
+        "enable"
+      ]
+    )
+    (mkFormatterModule {
+      name = "ruff-check";
+      package = "ruff";
+      args = [
         "check"
         "--fix"
       ];
@@ -38,6 +30,6 @@ in
         "*.py"
         "*.pyi"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/ruff-format.nix
+++ b/programs/ruff-format.nix
@@ -1,38 +1,24 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.ruff-format;
-in
+{ lib, mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
   imports = [
-    (lib.mkRenamedOptionModule [ "programs" "ruff" "format" ] [ "programs" "ruff-format" "enable" ])
-  ];
-
-  options.programs.ruff-format = {
-    enable = lib.mkEnableOption "ruff formatter" // {
-      description = ''
-        Whether to enable the Ruff formatter, an extremely fast Python code formatter
-        designed as a drop-in replacement for Black.
-      '';
-    };
-
-    package = lib.mkPackageOption pkgs "ruff" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.ruff-format = lib.mkIf cfg.enable {
-      command = cfg.package;
-      options = lib.mkBefore [ "format" ];
+    (lib.mkRenamedOptionModule
+      [ "programs" "ruff" "format" ]
+      [
+        "programs"
+        "ruff-format"
+        "enable"
+      ]
+    )
+    (mkFormatterModule {
+      name = "ruff-format";
+      package = "ruff";
+      args = [ "format" ];
       includes = [
         "*.py"
         "*.pyi"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/rufo.nix
+++ b/programs/rufo.nix
@@ -1,25 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.rufo;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.rufo = {
-    enable = lib.mkEnableOption "rufo";
-    package = lib.mkPackageOption pkgs "rufo" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.rufo = {
-      command = cfg.package;
-      options = [ "-x" ];
+  imports = [
+    (mkFormatterModule {
+      name = "rufo";
+      args = [ "-x" ];
       includes = [ "*.rb" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/rustfmt.nix
+++ b/programs/rustfmt.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,8 +10,18 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "rustfmt";
+      args = [
+        "--config"
+        "skip_children=true"
+      ];
+      includes = [ "*.rs" ];
+    })
+  ];
+
   options.programs.rustfmt = {
-    enable = lib.mkEnableOption "rustfmt";
     edition = lib.mkOption {
       type = lib.types.str;
       default = "2021";
@@ -19,19 +29,14 @@ in
         Rust edition to target when formatting
       '';
     };
-    package = lib.mkPackageOption pkgs "rustfmt" { };
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.rustfmt = {
-      command = "${cfg.package}/bin/rustfmt";
       options = [
         "--edition"
         cfg.edition
-        "--config"
-        "skip_children=true"
       ];
-      includes = [ "*.rs" ];
     };
   };
 }

--- a/programs/scalafmt.nix
+++ b/programs/scalafmt.nix
@@ -1,27 +1,14 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.scalafmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.scalafmt = {
-    enable = lib.mkEnableOption "scalafmt";
-    package = lib.mkPackageOption pkgs "scalafmt" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.scalafmt = {
-      command = cfg.package;
+  imports = [
+    (mkFormatterModule {
+      name = "scalafmt";
       includes = [
         "*.sbt"
         "*.scala"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/shellcheck.nix
+++ b/programs/shellcheck.nix
@@ -1,23 +1,10 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.shellcheck;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ "zimbatm" ];
 
-  options.programs.shellcheck = {
-    enable = lib.mkEnableOption "shellcheck";
-    package = lib.mkPackageOption pkgs "shellcheck" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.shellcheck = {
-      command = cfg.package;
+  imports = [
+    (mkFormatterModule {
+      name = "shellcheck";
       includes = [
         "*.sh"
         "*.bash"
@@ -25,6 +12,6 @@ in
         "*.envrc"
         "*.envrc.*"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/shfmt.nix
+++ b/programs/shfmt.nix
@@ -1,7 +1,7 @@
 {
-  lib,
-  pkgs,
   config,
+  lib,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,9 +10,24 @@ in
 {
   meta.maintainers = [ "zimbatm" ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "shfmt";
+      args = [
+        "-s"
+        "-w"
+      ];
+      includes = [
+        "*.sh"
+        "*.bash"
+        # direnv
+        "*.envrc"
+        "*.envrc.*"
+      ];
+    })
+  ];
+
   options.programs.shfmt = {
-    enable = lib.mkEnableOption "shfmt";
-    package = lib.mkPackageOption pkgs "shfmt" { };
     indent_size = lib.mkOption {
       type = lib.types.nullOr lib.types.int;
       default = 2;
@@ -26,24 +41,9 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    settings.formatter.shfmt = {
-      command = cfg.package;
-      options =
-        (lib.optionals (!isNull cfg.indent_size) [
-          "-i"
-          (toString cfg.indent_size)
-        ])
-        ++ [
-          "-s"
-          "-w"
-        ];
-      includes = [
-        "*.sh"
-        "*.bash"
-        # direnv
-        "*.envrc"
-        "*.envrc.*"
-      ];
-    };
+    settings.formatter.shfmt.options = lib.optionals (!isNull cfg.indent_size) [
+      "-i"
+      (toString cfg.indent_size)
+    ];
   };
 }

--- a/programs/sqlfluff.nix
+++ b/programs/sqlfluff.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -38,40 +38,26 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "sqlfluff";
+      args = [ "format" ];
+      includes = [ "*.sql" ];
+    })
+  ];
+
   options.programs.sqlfluff = {
-    enable = lib.mkEnableOption "sqlfluff";
-
-    package = lib.mkPackageOption pkgs "sqlfluff" { };
-
     dialect = lib.mkOption {
       description = "The sql dialect to use for formatting";
       type = lib.types.enum dialects;
       default = "ansi";
       example = "sqlite";
     };
-
-    includes = lib.mkOption {
-      description = "Array of patterns (globs) to use to find files to format";
-      type = lib.types.nullOr (lib.types.listOf lib.types.str);
-      default = [ "*.sql" ];
-    };
-
-    excludes = lib.mkOption {
-      description = "Array of patterns (globs) to exclude files or directories to format";
-      type = lib.types.nullOr (lib.types.listOf lib.types.str);
-      default = [ ];
-    };
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.sqlfluff = {
-      command = cfg.package;
-      options = [
-        "format"
-        "--dialect=${cfg.dialect}"
-      ];
-      includes = cfg.includes;
-      excludes = cfg.excludes;
+      options = [ "--dialect=${cfg.dialect}" ];
     };
   };
 }

--- a/programs/sqruff.nix
+++ b/programs/sqruff.nix
@@ -1,42 +1,15 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.sqruff;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.sqruff = {
-    enable = lib.mkEnableOption "sqruff";
-
-    package = lib.mkPackageOption pkgs "sqruff" { };
-
-    includes = lib.mkOption {
-      description = "Array of patterns (globs) to use to find files to format";
-      type = lib.types.nullOr (lib.types.listOf lib.types.str);
-      default = [ "*.sql" ];
-    };
-
-    excludes = lib.mkOption {
-      description = "Array of patterns (globs) to exclude files or directories to format";
-      type = lib.types.nullOr (lib.types.listOf lib.types.str);
-      default = [ ];
-    };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.sqruff = {
-      command = cfg.package;
-      options = [
+  imports = [
+    (mkFormatterModule {
+      name = "sqruff";
+      args = [
         "fix"
         "--force"
       ];
-      includes = cfg.includes;
-      excludes = cfg.excludes;
-    };
-  };
+      includes = [ "*.sql" ];
+    })
+  ];
 }

--- a/programs/statix.nix
+++ b/programs/statix.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -19,9 +20,14 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "statix";
+      includes = [ "*.nix" ];
+    })
+  ];
+
   options.programs.statix = {
-    enable = lib.mkEnableOption "statix";
-    package = lib.mkPackageOption pkgs "statix" { };
     disabled-lints = lib.mkOption {
       description = ''
         List of ignored lints. Run `statix list` to see all available lints.
@@ -36,12 +42,10 @@ in
     settings.formatter.statix = {
       # statix doesn't support multiple file targets
       command = pkgs.writeShellScriptBin "statix-fix" ''
-        for file in "''$@"; do
-          ${lib.getExe pkgs.statix} fix --config '${toString settingsDir}/statix.toml' "$file"
+        for file in "$@"; do
+          ${lib.getExe cfg.package} fix --config '${toString settingsDir}/statix.toml' "$file"
         done
       '';
-      options = [ ];
-      includes = [ "*.nix" ];
     };
   };
 }

--- a/programs/stylish-haskell.nix
+++ b/programs/stylish-haskell.nix
@@ -1,28 +1,15 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.stylish-haskell;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.stylish-haskell = {
-    enable = lib.mkEnableOption "stylish-haskell";
-    package = lib.mkPackageOption pkgs "stylish-haskell" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.stylish-haskell = {
-      command = cfg.package;
-      options = [
+  imports = [
+    (mkFormatterModule {
+      name = "stylish-haskell";
+      args = [
         "-i"
         "-r"
       ];
       includes = [ "*.hs" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/stylua.nix
+++ b/programs/stylua.nix
@@ -2,15 +2,14 @@
   lib,
   pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
   inherit (lib.types)
     bool
     int
-    str
     enum
-    listOf
     nullOr
     ;
 
@@ -172,35 +171,23 @@ in
 {
   meta.maintainers = [ "sebaszv" ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "stylua";
+      includes = [ "*.lua" ];
+    })
+  ];
+
   options.programs.stylua = {
-    enable = lib.mkEnableOption "stylua";
-    package = lib.mkPackageOption pkgs "stylua" { };
-
     settings = settingsSchema;
-
-    includes = lib.mkOption {
-      description = "Path/file patterns to include for StyLua";
-      type = listOf str;
-      default = [ "*.lua" ];
-    };
-    excludes = lib.mkOption {
-      description = "Path/file patterns to exclude for StyLua";
-      type = listOf str;
-      default = [ ];
-    };
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.stylua = {
-      command = cfg.package;
       options = lib.mkIf (settingsFile != null) [
         "--config-path"
         (toString settingsFile)
       ];
-      inherit (cfg)
-        includes
-        excludes
-        ;
     };
   };
 }

--- a/programs/swift-format.nix
+++ b/programs/swift-format.nix
@@ -1,25 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.swift-format;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.swift-format = {
-    enable = lib.mkEnableOption "swift-format";
-    package = lib.mkPackageOption pkgs "swift-format" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.swift-format = {
-      command = cfg.package;
-      options = [ "-i" ];
+  imports = [
+    (mkFormatterModule {
+      name = "swift-format";
+      args = [ "-i" ];
       includes = [ "*.swift" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/taplo.nix
+++ b/programs/taplo.nix
@@ -1,25 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.taplo;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.taplo = {
-    enable = lib.mkEnableOption "taplo";
-    package = lib.mkPackageOption pkgs "taplo" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.taplo = {
-      command = cfg.package;
-      options = [ "format" ];
+  imports = [
+    (mkFormatterModule {
+      name = "taplo";
+      args = [ "format" ];
       includes = [ "*.toml" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/templ.nix
+++ b/programs/templ.nix
@@ -1,25 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.templ;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.templ = {
-    enable = lib.mkEnableOption "templ";
-    package = lib.mkPackageOption pkgs "templ" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.templ = {
-      command = "${cfg.package}/bin/templ";
-      options = [ "fmt" ];
+  imports = [
+    (mkFormatterModule {
+      name = "templ";
+      args = [ "fmt" ];
       includes = [ "*.templ" ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/terraform.nix
+++ b/programs/terraform.nix
@@ -1,31 +1,18 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.terraform;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.terraform = {
-    enable = lib.mkEnableOption "terraform";
-    # opentofu is the opensource version of terraform and cached in cache.nixos.org
-    package = lib.mkPackageOption pkgs "opentofu" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.terraform = {
-      command = cfg.package;
-      options = [ "fmt" ];
+  imports = [
+    (mkFormatterModule {
+      name = "terraform";
+      package = "opentofu";
+      args = [ "fmt" ];
       # All opentofu-supported files
       includes = [
         "*.tf"
         "*.tfvars"
         "*.tftest.hcl"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/texfmt.nix
+++ b/programs/texfmt.nix
@@ -1,24 +1,11 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.texfmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.texfmt = {
-    enable = lib.mkEnableOption "texfmt";
-    package = lib.mkPackageOption pkgs "tex-fmt" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.texfmt = {
-      command = lib.getExe' cfg.package "tex-fmt";
-      options = [ ];
+  imports = [
+    (mkFormatterModule {
+      name = "texfmt";
+      package = "tex-fmt";
       includes = [
         "*.tex"
         "*.sty"
@@ -26,6 +13,6 @@ in
         "*.bib"
         "*.cmh"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/toml-sort.nix
+++ b/programs/toml-sort.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,17 +10,21 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "toml-sort";
+      args = [ "-i" ];
+      includes = [ "*.toml" ];
+    })
+  ];
+
   options.programs.toml-sort = {
-    enable = lib.mkEnableOption "toml-sort";
-    package = lib.mkPackageOption pkgs "toml-sort" { };
     all = lib.mkEnableOption "sort ALL keys";
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.toml-sort = {
-      command = "${cfg.package}/bin/toml-sort";
-      options = [ "-i" ] ++ lib.optional cfg.all "--all";
-      includes = [ "*.toml" ];
+      options = lib.optional cfg.all "--all";
     };
   };
 }

--- a/programs/typos.nix
+++ b/programs/typos.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,10 +10,15 @@ in
 {
   meta.maintainers = [ "adam-gaia" ];
 
-  options.programs.typos = {
-    enable = lib.mkEnableOption "typos";
-    package = lib.mkPackageOption pkgs "typos" { };
+  imports = [
+    (mkFormatterModule {
+      name = "typos";
+      args = [ "--write-changes" ];
+      includes = [ "*" ];
+    })
+  ];
 
+  options.programs.typos = {
     threads = lib.mkOption {
       type = lib.types.nullOr lib.types.int;
       default = null;
@@ -118,10 +123,8 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.typos = {
-      command = cfg.package;
       options =
-        [ "--write-changes" ]
-        ++ (lib.optionals (!isNull cfg.threads) [
+        (lib.optionals (!isNull cfg.threads) [
           "--threads"
           (toString cfg.threads)
         ])
@@ -145,9 +148,6 @@ in
         ++ lib.optional cfg.noCheckFilenames "--no-check-filenames"
         ++ lib.optional cfg.noCheckFiles "--no-check-files"
         ++ lib.optional cfg.noUnicode "--no-unicode";
-      includes = [
-        "*"
-      ];
     };
   };
 }

--- a/programs/typstfmt.nix
+++ b/programs/typstfmt.nix
@@ -1,27 +1,14 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.typstfmt;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.typstfmt = {
-    enable = lib.mkEnableOption "typstfmt";
-    package = lib.mkPackageOption pkgs "typstfmt" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.typstfmt = {
-      command = cfg.package;
+  imports = [
+    (mkFormatterModule {
+      name = "typstfmt";
       includes = [
         "*.typ"
         "*.typst"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/typstyle.nix
+++ b/programs/typstyle.nix
@@ -1,29 +1,15 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.typstyle;
-  inherit (lib) mkEnableOption mkIf mkPackageOption;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ "SigmaSquadron" ];
 
-  options.programs.typstyle = {
-    enable = mkEnableOption "typstyle";
-    package = mkPackageOption pkgs "typstyle" { };
-  };
-
-  config = mkIf cfg.enable {
-    settings.formatter.typstyle = {
-      command = cfg.package;
-      options = [ "-i" ];
+  imports = [
+    (mkFormatterModule {
+      name = "typstyle";
+      args = [ "-i" ];
       includes = [
         "*.typ"
         "*.typst"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/yamlfmt.nix
+++ b/programs/yamlfmt.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -12,9 +13,17 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "yamlfmt";
+      includes = [
+        "*.yaml"
+        "*.yml"
+      ];
+    })
+  ];
+
   options.programs.yamlfmt = {
-    enable = lib.mkEnableOption "yamlfmt";
-    package = lib.mkPackageOption pkgs "yamlfmt" { };
     settings = lib.mkOption {
       type = lib.types.submodule { freeformType = settingsFormat.type; };
       default = { };
@@ -28,11 +37,6 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.yamlfmt = {
-      command = cfg.package;
-      includes = [
-        "*.yaml"
-        "*.yml"
-      ];
       options = lib.optional (
         cfg.settings != { }
       ) "-conf=${settingsFormat.generate "yamlfmt.conf" cfg.settings}";

--- a/programs/zig.nix
+++ b/programs/zig.nix
@@ -1,28 +1,15 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
-let
-  cfg = config.programs.zig;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
-  options.programs.zig = {
-    enable = lib.mkEnableOption "zig";
-    package = lib.mkPackageOption pkgs "zig" { };
-  };
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.zig = {
-      command = cfg.package;
-      options = [ "fmt" ];
+  imports = [
+    (mkFormatterModule {
+      name = "zig";
+      args = [ "fmt" ];
       includes = [
         "*.zig"
         "*.zon"
       ];
-    };
-  };
+    })
+  ];
 }

--- a/programs/zprint.nix
+++ b/programs/zprint.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pkgs,
   config,
+  mkFormatterModule,
   ...
 }:
 let
@@ -10,16 +10,20 @@ in
 {
   meta.maintainers = [ ];
 
+  imports = [
+    (mkFormatterModule {
+      name = "zprint";
+      args = [ "--write" ];
+      includes = [
+        "*.clj"
+        "*.cljc"
+        "*.cljs"
+        "*.edn"
+      ];
+    })
+  ];
+
   options.programs.zprint = {
-    enable = lib.mkEnableOption "zprint";
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.zprint;
-      defaultText = lib.literalExpression "pkgs.zprint";
-      description = ''
-        zprint derivation to use.
-      '';
-    };
     zprintOpts = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;
@@ -32,15 +36,8 @@ in
 
   config = lib.mkIf cfg.enable {
     settings.formatter.zprint = {
-      command = cfg.package;
       # zprint options must be first
-      options = (lib.optional (cfg.zprintOpts != null) cfg.zprintOpts) ++ [ "--write" ];
-      includes = [
-        "*.clj"
-        "*.cljc"
-        "*.cljs"
-        "*.edn"
-      ];
+      options = lib.optional (cfg.zprintOpts != null) cfg.zprintOpts;
     };
   };
 }


### PR DESCRIPTION
A common complaint / observation is that treefmt-nix config tend to be a mix between enabled programs, and treefmt settings to override includes/excludes/priority. Some programs have those options available directly, but not all of them.

In order to fix that, this commit introduces `mkFormatterModule`, a function that generates a regular module structure based on a few parameters. And that support the includes / excludes / priority out of the box.

A few of the programs are already converted to that format. Ideally all of them are getting converted soon.