### PR TITLE
Fix typo: Biome -> elm-format

### DIFF
--- a/programs/elm-format.nix
+++ b/programs/elm-format.nix
@@ -23,7 +23,7 @@ in
     };
 
     includes = lib.mkOption {
-      description = "Path / file patterns to include for Biome";
+      description = "Path / file patterns to include for elm-format";
       type = lib.types.listOf lib.types.str;
       example = [ "*.elm" ];
       default = [ "*.elm" ];


### PR DESCRIPTION
At least, I'm pretty sure this was a typo.
