### PR TITLE
Revert "wrapper: add treefmt-nix executable to output (#243)"

### DIFF
--- a/module-options.nix
+++ b/module-options.nix
@@ -206,21 +206,8 @@ in
                     "$@"
                 '';
             x = pkgs.writeShellScriptBin "treefmt" code;
-            # used by tooling to detect if treefmt was wrapped or not
-            y = pkgs.writeShellScriptBin "treefmt-nix" code;
           in
-          (
-            pkgs.symlinkJoin {
-              name = "treefmt-nix";
-              paths = [
-                x
-                y
-              ];
-            }
-            // {
-              meta = config.package.meta // x.meta;
-            }
-          );
+          (x // { meta = config.package.meta // x.meta; });
       };
       programs = mkOption {
         type = types.attrsOf types.package;


### PR DESCRIPTION
This reverts commit a10a0cbe2196120aa90e4f86d459376e1d108d58.

This was originally added to make it easier to integrate treefmt-nix into none-ls. none-ls ended up implementing a different approach which doesn't need this wrapper script:
<https://github.com/nvimtools/none-ls.nvim/pull/192>.

In the interest of keeping things simple, I propose that we get rid of this wrapper.