### PR TITLE
Fixes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -120,14 +120,20 @@ let
     # NOTE: keep in sync with submoduleWith
     nixpkgs.lib.evalModules {
       modules = all-modules nixpkgs ++ [ configuration ];
-      specialArgs = {
-        inherit mkFormatterModule;
-      };
+      specialArgs = defaultSpecialArgs;
     };
 
   /**
+    The built-in specialArgs for treefmt-nix.
+    These are module arguments that are passed to all treefmt-nix modules.
+  */
+  defaultSpecialArgs = {
+    inherit mkFormatterModule;
+  };
+
+  /**
     Invoke treefmt-nix as a submodule, integrating this into a larger configuration management system.
-  
+
     Unlike in `evalModule`, the caller is responsible for setting `_module.args.pkgs` inside the submodule.
 
     # Inputs
@@ -151,9 +157,7 @@ let
     # NOTE: keep in sync with evalModule
     lib.types.submoduleWith {
       modules = submodule-modules ++ modules;
-      specialArgs = {
-        inherit mkFormatterModule;
-      } // specialArgs;
+      specialArgs = defaultSpecialArgs // specialArgs;
     };
 
   # Returns a treefmt.toml generated from the passed configuration.

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -12,6 +12,7 @@ let
     mkOption
     types
     ;
+  treefmt-nix-lib = import ./.;
 in
 {
   options = {
@@ -32,8 +33,8 @@ in
             By default treefmt-nix will set the `formatter.<system>` attribute of the flake,
             used by the `nix fmt` command.
           '';
-          type = types.submoduleWith {
-            modules = (import ./.).submodule-modules ++ [
+          type = treefmt-nix-lib.submoduleWith lib {
+            modules = [
               {
                 options.pkgs = lib.mkOption {
                   default = pkgs;
@@ -61,7 +62,6 @@ in
                     Path to the root of the project on which treefmt operates
                   '';
                 };
-
               }
             ];
           };

--- a/programs/genemichaels.nix
+++ b/programs/genemichaels.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   config,
+  options,
   ...
 }:
 let
@@ -25,12 +26,21 @@ let
     mkOption
     mkPackageOption
     ;
+
+  showOptionParent =
+    opt: _n:
+    assert opt._type == "option";
+    lib.showOption (lib.take (lib.length opt.loc - 1) opt.loc);
 in
 {
   meta.maintainers = [ "djacu" ];
 
   options.programs.genemichaels = {
-    enable = mkEnableOption "genemichaels";
+    enable = mkEnableOption "genemichaels" // {
+      description = ''
+        Whether to enable [`genemichaels`](https://github.com/andrewbaxter/genemichaels/blob/master/readme_genemichaels.md), a Rust code formatter.
+      '';
+    };
     package = mkPackageOption pkgs "genemichaels" { };
 
     # Configuration scheme for genemichaels, which we generate .genemichaels.json with.
@@ -114,8 +124,9 @@ in
     settingsFile = mkOption {
       description = "The configuration file used by `genemichaels`.";
       type = types.path;
-      example = ./.genemichaels.json;
+      example = lib.literalExpression ''./.genemichaels.json'';
       default = configFormat.generate ".genemichaels.json" cfg.settings;
+      defaultText = lib.literalMD "Generated JSON file from `${showOptionParent options.programs.genemichaels.settings.max_width 1}`";
     };
 
     threadCount = mkOption {


### PR DESCRIPTION
- Fixes https://github.com/numtide/treefmt-nix/pull/288#issuecomment-2568331807
- Fixes #292
- Adds `submoduleWith` function to lib, to make the alternate entrypoint contract visible (it's different wrt `pkgs` and return value - see doc)
- Fixes doc rendering
