### PR TITLE
dos2unix: explicitly set `mainProgram` to `dos2unix`

### DIFF
--- a/programs/dos2unix.nix
+++ b/programs/dos2unix.nix
@@ -3,11 +3,17 @@
   ...
 }:
 {
-  meta.maintainers = [ ];
+  meta.maintainers = [ "sebaszv" ];
 
+  /*
+    Package `dos2unix` has several binaries.
+    Since `meta.mainProgram` isn't defined,
+    we specify which to use.
+  */
   imports = [
     (mkFormatterModule {
       name = "dos2unix";
+      mainProgram = "dos2unix";
       args = [ "--keepdate" ];
       includes = [ "*" ];
     })


### PR DESCRIPTION
The package `dos2unix` doesn't have `meta.mainProgram`
defined since it includes several binaries.

At present `lib.getExe` was inferring that we wanted the
path to `dos2unix`.

Here we now specify that we want `dos2unix`, avoiding
what is specified in the evaluation warning:

> *evaluation warning:* `getExe`: Package "dos2unix-7.5.2" does not have
> the `meta.mainProgram` attribute. We'll assume that the main program
> has the same name for now, but this behavior is deprecated, because
> it leads to surprising errors when the assumption does not hold. If
> the package has a main program, please set `meta.mainProgram` in its
> definition to make this warning go away. Otherwise, if the package
> does not have a main program, or if you don't control its definition,
> use `getExe'` to specify the name to the program, such as
> `lib.getExe' foo "bar"`.
