### PR TITLE
Fix dead documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ programs.gofmt.enable = true;
   options or includes this way.
 
 For detailed description of the options, refer to the `treefmt`
-[documentation](https://treefmt.com/configure.html).
+[documentation](https://treefmt.com/latest/getting-started/configure/).
 
 ## Project structure
 


### PR DESCRIPTION
Small nitpick I noticed while browsing the README.
[The current link leads to a broken page](https://treefmt.com/configure.html), but [this one](https://treefmt.com/latest/getting-started/configure/) looks fine.