### PR TITLE
hujsonfmt: json formatter supporting comments

### DIFF
--- a/programs/hujsonfmt.nix
+++ b/programs/hujsonfmt.nix
@@ -1,0 +1,13 @@
+{ mkFormatterModule, ... }:
+{
+  meta.maintainers = [ ];
+
+  imports = [
+    (mkFormatterModule {
+      name = "hujsonfmt";
+      args = [ "-w" ];
+      includes = [ "*.json" "*.jsonc" ];
+    })
+  ];
+}
+


### PR DESCRIPTION
I tried jsonfmt5 but it unquoted keys which broke my json

hujsonfmt replace spaces with tabs and it doesn't seem configurable. 
When I tried using it I got
```
ERRO formatter | hujsonfmt: failed to apply with options '[-w]': exit status 1

hujson: line 2, column 5: invalid literal: desktop
usage: hujsonfmt [flags] [path ...]
  -d	display diffs instead of rewriting files
  -l	list files whose formatting differs from hujsonfmt's
  -m	minify results
  -s	standardize results to plain JSON
  -w	write result to (source) file instead of stdout
```
