### PR TITLE
sqlfluff: disable default dialect

### DIFF
--- a/examples/formatter-sqlfluff.toml
+++ b/examples/formatter-sqlfluff.toml
@@ -3,4 +3,4 @@
 command = "sqlfluff"
 excludes = []
 includes = ["*.sql"]
-options = ["format", "--dialect=ansi"]
+options = ["format"]

--- a/programs/sqlfluff.nix
+++ b/programs/sqlfluff.nix
@@ -49,15 +49,17 @@ in
   options.programs.sqlfluff = {
     dialect = lib.mkOption {
       description = "The sql dialect to use for formatting";
-      type = lib.types.enum dialects;
-      default = "ansi";
+      type = with lib.types; nullOr (enum dialects);
+      default = null;
       example = "sqlite";
     };
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.sqlfluff = {
-      options = [ "--dialect=${cfg.dialect}" ];
+      options = lib.optionals (cfg.dialect != null) [
+        "--dialect=${cfg.dialect}"
+      ];
     };
   };
 }


### PR DESCRIPTION
Current `programs.sqlfluff.enable = true` enforces command-line option `--dialect=ansi`. This overrides project-level sqlfluff settings; for example, even if I have `pyproject.toml` with the following setting in a project filled with Databricks SQL files, `nix fmt` fails:

```toml
[tool.sqlfluff.core]
dialect = "databricks"
```

This PR removes the default option `--dialect=ansi`.