### PR TITLE
rustfmt: fix for Rust packages from rust-overlay

### DIFF
--- a/programs/rustfmt.nix
+++ b/programs/rustfmt.nix
@@ -13,6 +13,7 @@ in
   imports = [
     (mkFormatterModule {
       name = "rustfmt";
+      mainProgram = "rustfmt";
       args = [
         "--config"
         "skip_children=true"


### PR DESCRIPTION
When I use the Rust toolchain installed from `rust-overlay` or `Fenix` I've got an error.

```
evaluation warning: getExe: Package rust-nightly-complete-with-components-2025-02-01 does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
2025/02/10 00:56:39 INFO using config file: /nix/store/n65qj2fiz3f64smqffhqp54nimgp4ax4-treefmt.toml
Error: failed to create composite formatter: failed to initialise formatter rustfmt: formatter command not found in PATH
```

This MR fixes compatibility with the `rust-overlay` toolchains.