### PR TITLE
All GLSL extensions to clangfmt

### DIFF
--- a/examples/formatter-clang-format.toml
+++ b/examples/formatter-clang-format.toml
@@ -2,5 +2,5 @@
 [formatter.clang-format]
 command = "clang-format"
 excludes = []
-includes = ["*.c", "*.cc", "*.cpp", "*.h", "*.hh", "*.hpp"]
+includes = ["*.c", "*.cc", "*.cpp", "*.h", "*.hh", "*.hpp", "*.glsl", "*.vert", ".tesc", ".tese", ".geom", ".frag", ".comp"]
 options = ["-i"]

--- a/programs/clang-format.nix
+++ b/programs/clang-format.nix
@@ -15,6 +15,13 @@
         "*.h"
         "*.hh"
         "*.hpp"
+        "*.glsl"
+        "*.vert"
+        ".tesc"
+        ".tese"
+        ".geom"
+        ".frag"
+        ".comp"
       ];
     })
   ];


### PR DESCRIPTION
Clang-Format can format GLSL files too. Extensions are obviously GLSL as well as 
https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/
```
.vert - a vertex shader
.tesc - a tessellation control shader
.tese - a tessellation evaluation shader
.geom - a geometry shader
.frag - a fragment shader
.comp - a compute shader
```