### PR TITLE
fix: potential issue with `cfg.enable` check

### DIFF
--- a/programs/golines.nix
+++ b/programs/golines.nix
@@ -1,9 +1,4 @@
-{
-  lib,
-  config,
-  mkFormatterModule,
-  ...
-}:
+{ lib, config, mkFormatterModule, ... }:
 let
   cfg = config.programs.golines;
 in
@@ -25,7 +20,7 @@ in
     })
   ];
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf (cfg.enable != null && cfg.enable) {
     settings.formatter.golines = {
       command = "${cfg.package}/bin/golines";
     };


### PR DESCRIPTION
In the original code, there was a conditional check using `lib.mkIf cfg.enable`, which could cause an error if `cfg.enable` was undefined. I’ve updated it to a safer check:  
```nix
lib.mkIf (cfg.enable != null && cfg.enable)
```  
This ensures that `cfg.enable` is not null and is set to true, preventing potential errors when `cfg.enable` is not defined.