### PR TITLE
chore: fix default value for undefined `cfg.enable`

### DIFF
--- a/programs/fish_indent.nix
+++ b/programs/fish_indent.nix
@@ -13,7 +13,7 @@ in
     })
   ];
 
-  config = lib.mkIf (cfg.enable or false) {  # Защита от случая, если `cfg.enable` не определено
+  config = lib.mkIf (cfg.enable or false) {
     settings.formatter.fish_indent = {
       command = "${cfg.package}/bin/fish_indent";
     };

--- a/programs/fish_indent.nix
+++ b/programs/fish_indent.nix
@@ -1,9 +1,3 @@
-{
-  lib,
-  config,
-  mkFormatterModule,
-  ...
-}:
 let
   cfg = config.programs.fish_indent;
 in
@@ -19,7 +13,7 @@ in
     })
   ];
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf (cfg.enable or false) {  # Защита от случая, если `cfg.enable` не определено
     settings.formatter.fish_indent = {
       command = "${cfg.package}/bin/fish_indent";
     };


### PR DESCRIPTION
Fixed an issue where `cfg.enable` would not default to `false` if undefined, ensuring the config block is skipped when missing or set to `false`. Also used `lib.mkIf` for proper conditional application.