### PR TITLE
just: format justfile in subdirectories

### DIFF
--- a/programs/just.nix
+++ b/programs/just.nix
@@ -6,6 +6,8 @@
   ...
 }:
 let
+  # Search 'justfile' in subdirectories too. This isn't needed for filename starting with `*.`.
+  alsoSearchSubdirectory = lib.lists.concatMap (fileName: [ fileName ] ++ [ "*/${fileName}" ]);
   cfg = config.programs.just;
 in
 {
@@ -14,17 +16,22 @@ in
   imports = [
     (mkFormatterModule {
       name = "just";
-      includes = [
-        "[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # 'justfile', case insensitive
-        ".[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # '.justfile', case insensitive
-        "*.[Jj][Uu][Ss][Tt]" # '.just' module, case insensitive
-        "*.[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # '.justfile' module, case insensitive
-      ];
+      includes =
+        alsoSearchSubdirectory [
+          "[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # 'justfile', case insensitive
+          ".[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # '.justfile', case insensitive
+        ]
+        ++ [
+          "*.[Jj][Uu][Ss][Tt]" # '.just' module, case insensitive
+          "*.[Jj][Uu][Ss][Tt][Ff][Ii][Ll][Ee]" # '.justfile' module, case insensitive
+        ];
     })
   ];
 
   config = lib.mkIf cfg.enable {
     settings.formatter.just = {
+      # just itself doesn't comply with the treefmt spec, as the --justfile flags expects a single argument
+      # the spec requires the formatter to accept multiple file names as arguments (see https://treefmt.com/latest/reference/formatter-spec/#1-files-passed-as-arguments).
       command = pkgs.bash;
       options = [
         "-euc"


### PR DESCRIPTION
Given the following projects:
```
.
├── foobar
│   └── justfile
└── justfile
```
the previous implementation would have just reformatted `./justfile` but not `./foobar/justfile`.

I also simplified the previous bash implementation by re-using mkFormatterModule 