### PR TITLE
Supress verbose git stuff

### DIFF
--- a/module-options.nix
+++ b/module-options.nix
@@ -259,14 +259,14 @@ in
               [init]
                 defaultBranch = main
               EOF
-              git init
+              git init --quiet
               git add .
               git commit -m init --quiet
               export LANG=${if pkgs.stdenv.isDarwin then "en_US.UTF-8" else "C.UTF-8"}
               export LC_ALL=${if pkgs.stdenv.isDarwin then "en_US.UTF-8" else "C.UTF-8"}
               treefmt --version
               treefmt --no-cache
-              git status
+              git status --short
               git --no-pager diff --exit-code
               touch $out
             '';


### PR DESCRIPTION
`nix log ...-treefmt-check.drv` before:

```console
error: builder for '/nix/store/ihmf1fxbaqylkylnr59r0g55l3zwi0ji-treefmt-check.drv' failed with exit code 1
Initialized empty Git repository in /build/project/.git/
treefmt v0.0.1+dev2025/04/28 03:20:40 INFO using config file: /nix/store/rynk5nwplarkgr2k8mql3gc00j7c3v7b-treefmt.toml
traversed 73 files
emitted 57 files for processing
formatted 57 files (1 changed) in 258ms
On branch main
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   some_file
        modified:   some_other_file

no changes added to commit (use "git add" and/or "git commit -a")

# ... the diff
```

`nix log ...-treefmt-check.drv` after:

```console
error: builder for '/nix/store/ihmf1fxbaqylkylnr59r0g55l3zwi0ji-treefmt-check.drv' failed with exit code 1
treefmt v0.0.1+dev2025/04/28 03:20:40 INFO using config file: /nix/store/rynk5nwplarkgr2k8mql3gc00j7c3v7b-treefmt.toml
traversed 73 files
emitted 57 files for processing
formatted 57 files (1 changed) in 258ms
  M some_file
  M some_other_file

# ... the diff
```