### PR TITLE
fix defaultText for `pkgs` option using `literalMD`

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -38,7 +38,7 @@ in
               {
                 options.pkgs = lib.mkOption {
                   default = pkgs;
-                  defaultText = "`pkgs` (module argument of `perSystem`)";
+                  defaultText = lib.literalMD "`pkgs` (module argument of `perSystem`)";
                 };
                 options.flakeFormatter = lib.mkOption {
                   type = types.bool;


### PR DESCRIPTION
Passing a non-literal string to `example` or `defaultText` causes the docs to render the value using `lib.generators.toPretty`.

If you want to use markdown, use `literalMD`. If you want to pass a nix expression, use `literalExpression`.
