### PR TITLE
Use `flake.nix` for the project root when dealing with flakes

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -62,6 +62,8 @@ in
                     Path to the root of the project on which treefmt operates
                   '';
                 };
+
+                config.projectRootFile = lib.mkDefault "flake.nix";
               }
             ];
           };


### PR DESCRIPTION
The default value for `config.projectRootFile` is `.git/config`, which is a nice default that doesn't assume flakes (because flakes are more controversial than git in the nix community :))

However, if you're using flake-parts, then you're definitely OK with flakes, and using `flake.nix` as a project root file makes sense.

As a consequence of this, subflakes now probably do what you expect. In other words, this fixes https://github.com/numtide/treefmt-nix/issues/357.

Side note: in the future, nix will expose a `PRJ_ROOT` env var that we could use instead. See
https://github.com/NixOS/nix/commit/76358748da95528f1a665455dae35dad61081dcb.