### PR TITLE
templ: adds needed go pkg

### DIFF
--- a/programs/templ.nix
+++ b/programs/templ.nix
@@ -1,4 +1,13 @@
-{ mkFormatterModule, ... }:
+{
+  config,
+  lib,
+  mkFormatterModule,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.templ;
+in
 {
   meta.maintainers = [ ];
 
@@ -9,4 +18,19 @@
       includes = [ "*.templ" ];
     })
   ];
+
+  config = lib.mkIf cfg.enable {
+    settings.formatter.templ = {
+      command = pkgs.writeShellApplication {
+        name = "templ";
+        runtimeInputs = [
+          pkgs.go
+          pkgs.templ
+        ];
+        text = ''
+          exec templ "$@"
+        '';
+      };
+    };
+  };
 }


### PR DESCRIPTION
templ throws an error on format check that its missing the go binary.  im not sure if this its the right way to do it. for me it works fine. i also tested it with throwing a templ file in the repo and everything. error is gone after that.

```
nent {\n\treturn templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {\n\t\ttempl_7745c5c3_W, ctx := templ_7745c5c3_Inpu
t.Writer, templ_7745c5c3_Input.Context\n\t\tif templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {\n\t\t\treturn templ_7745c5c3_CtxErr\t\t}\n\t\ttempl_7745c5c3_Buffer, templ_7
745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)\n\t\tif !templ_7745c5c3_IsBuffer {\n\t\t\tdefer func() {\n\t\t\t\ttempl_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c
5c3_Buffer)\n\t\t\t\tif templ_7745c5c3_Err == nil {\n\t\t\t\t\ttempl_7745c5c3_Err = templ_7745c5c3_BufErr\n\t\t\t\t}\n\t\t\t}()\n\t\t}\n\t\tctx = templ.InitializeContext(ctx)\n\t\ttempl_7745
c5c3_Var11 := templ.GetChildren(ctx)\n\t\tif templ_7745c5c3_Var11 == nil {\n\t\t\ttempl_7745c5c3_Var11 = templ.NopComponent\n\t\t}\n\t\tctx = templ.ClearChildren(ctx)\n\t\ttempl_7745c5c3_Err
 = loginComponent(FormComponent(\"/login\", text, LoginFormInputComponent(), LoginFormButtonComponent())).Render(ctx, templ_7745c5c3_Buffer)\n\t\tif templ_7745c5c3_Err != nil {\n\t\t\treturn
 templ_7745c5c3_Err\n\t\t}\n\t\treturn nil\n\t})\n}\n\nfunc LogoutComponent(text string) templ.Component {\n\treturn templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.Gen
eratedComponentInput) (templ_7745c5c3_Err error) {\n\t\ttempl_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context\n\t\tif templ_7745c5c3_CtxErr := ctx.Err(); templ_7
745c5c3_CtxErr != nil {\n\t\t\treturn templ_7745c5c3_CtxErr\t\t}\n\t\ttempl_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)\n\t\tif !templ_7745c5c3_IsBuf
fer {\n\t\t\tdefer func() {\n\t\t\t\ttempl_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)\n\t\t\t\tif templ_7745c5c3_Err == nil {\n\t\t\t\t\ttempl_7745c5c3_Err = templ_
7745c5c3_BufErr\n\t\t\t\t}\n\t\t\t}()\n\t\t}\n\t\tctx = templ.InitializeContext(ctx)\n\t\ttempl_7745c5c3_Var12 := templ.GetChildren(ctx)\n\t\tif templ_7745c5c3_Var12 == nil {\n\t\t\ttempl_77
45c5c3_Var12 = templ.NopComponent\n\t\t}\n\t\tctx = templ.ClearChildren(ctx)\n\t\ttempl_7745c5c3_Err = loginComponent(FormComponent(\"/logout\", text, logoutFormInputComponent(), logoutFormB
uttonComponent())).Render(ctx, templ_7745c5c3_Buffer)\n\t\tif templ_7745c5c3_Err != nil {\n\t\t\treturn templ_7745c5c3_Err\n\t\t}\n\t\treturn nil\n\t})\n}\n\nfunc bodyComponent(content templ
.Component) templ.Component {\n\treturn templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {\n\t\ttempl_7745c5c3_W, ctx
 := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context\n\t\tif templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {\n\t\t\treturn templ_7745c5c3_CtxErr\t\t}\n\t\ttempl_7
745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)\n\t\tif !templ_7745c5c3_IsBuffer {\n\t\t\tdefer func() {\n\t\t\t\ttempl_7745c5c3_BufErr := templruntime.Re
leaseBuffer(templ_7745c5c3_Buffer)\n\t\t\t\tif templ_7745c5c3_Err == nil {\n\t\t\t\t\ttempl_7745c5c3_Err = templ_7745c5c3_BufErr\n\t\t\t\t}\n\t\t\t}()\n\t\t}\n\t\tctx = templ.InitializeConte
xt(ctx)\n\t\ttempl_7745c5c3_Var13 := templ.GetChildren(ctx)\n\t\tif templ_7745c5c3_Var13 == nil {\n\t\t\ttempl_7745c5c3_Var13 = templ.NopComponent\n\t\t}\n\t\tctx = templ.ClearChildren(ctx)\
n\t\ttempl_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, \"<body><div class=\\\"flex h-screen bg-lime-200\\\"><div class=\\\"m-auto\\\">\")\n\t\tif templ_7745c5c3_Err !=
 nil {\n\t\t\treturn templ_7745c5c3_Err\n\t\t}\n\t\ttempl_7745c5c3_Err = content.Render(ctx, templ_7745c5c3_Buffer)\n\t\tif templ_7745c5c3_Err != nil {\n\t\t\treturn templ_7745c5c3_Err\n\t\t
}\n\t\ttempl_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, \"</div></div><script defer type=\\\"text/javascript\\\" src=\\\"/static/deps/htmx/htmx.js\\\"></script></body
>\")\n\t\tif templ_7745c5c3_Err != nil {\n\t\t\treturn templ_7745c5c3_Err\n\t\t}\n\t\treturn nil\n\t})\n}\n\nfunc LoginPage(title string, content templ.Component) templ.Component {\n\treturn
 templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {\n\t\ttempl_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_
7745c5c3_Input.Context\n\t\tif templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {\n\t\t\treturn templ_7745c5c3_CtxErr\t\t}\n\t\ttempl_7745c5c3_Buffer, templ_7745c5c3_IsBuffer
 := templruntime.GetBuffer(templ_7745c5c3_W)\n\t\tif !templ_7745c5c3_IsBuffer {\n\t\t\tdefer func() {\n\t\t\t\ttempl_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)\n\t\
t\t\tif templ_7745c5c3_Err == nil {\n\t\t\t\t\ttempl_7745c5c3_Err = templ_7745c5c3_BufErr\n\t\t\t\t}\n\t\t\t}()\n\t\t}\n\t\tctx = templ.InitializeContext(ctx)\n\t\ttempl_7745c5c3_Var14 := te
mpl.GetChildren(ctx)\n\t\tif templ_7745c5c3_Var14 == nil {\n\t\t\ttempl_7745c5c3_Var14 = templ.NopComponent\n\t\t}\n\t\tctx = templ.ClearChildren(ctx)\n\t\ttempl_7745c5c3_Err = templruntime.
WriteString(templ_7745c5c3_Buffer, 15, \"<!doctype html><html>\")\n\t\tif templ_7745c5c3_Err != nil {\n\t\t\treturn templ_7745c5c3_Err\n\t\t}\n\t\ttempl_7745c5c3_Err = headerComponent(title)
.Render(ctx, templ_7745c5c3_Buffer)\n\t\tif templ_7745c5c3_Err != nil {\n\t\t\treturn templ_7745c5c3_Err\n\t\t}\n\t\ttempl_7745c5c3_Err = bodyComponent(content).Render(ctx, templ_7745c5c3_Bu
ffer)\n\t\tif templ_7745c5c3_Err != nil {\n\t\t\treturn templ_7745c5c3_Err\n\t\t}\n\t\ttempl_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, \"</html>\")\n\t\tif templ_774
5c5c3_Err != nil {\n\t\t\treturn templ_7745c5c3_Err\n\t\t}\n\t\treturn nil\n\t})\n}\nvar _ = templruntime.GeneratedTemplate": err: go command required, not found: exec: "go": executable file
 not found in $PATH: stderr:  ]
       > (✓) Format Complete [ count=1 errors=1 changed=0 duration=5.041651ms ]
       >
       > traversed 223 files
       > emitted 122 files for processing
       > formatted 121 files (0 changed) in 385ms
       > Error: failed to finalise formatting: formatting failures detected
       For full logs, run:
         nix log /nix/store/zih4lgri3wi1is18q2lwazziajpsn6ha-treefmt-check.drv
error: build of '/nix/store/brqw8lsca180xyy5igzqm1sj1raqv5k7-options.md.drv', '/nix/store/zih4lgri3wi1is18q2lwazziajpsn6ha-treefmt-check.drv' failed
```