### PR TITLE
fix: Fix flake check not working in repository with git-lfs

### DIFF
--- a/module-options.nix
+++ b/module-options.nix
@@ -238,6 +238,7 @@ in
             {
               buildInputs = [
                 pkgs.git
+                pkgs.git-lfs
                 config.build.wrapper
               ];
               meta.description = "Check that the project tree is formatted";


### PR DESCRIPTION
Adds `git-lfs` as runtime input to the defined `treefmt-check` script.

Rationale:
In repositories with `git-lfs` enabled and or custom processes, this might error out in a hard to debug way.
While this can be fixed with correct configuration or overwriting of the check, adding `git-lfs` will only add a minor overhead and reduce overall friction of downstream consumers.