### PR TITLE
bugfix: biome default organizeImports

### DIFF
--- a/examples/formatter-biome.toml
+++ b/examples/formatter-biome.toml
@@ -18,4 +18,4 @@ includes = [
     "*.jsonc",
     "*.css",
 ]
-options = ["format", "--write", "--no-errors-on-unmatched"]
+options = ["check", "--write", "--no-errors-on-unmatched"]

--- a/programs/biome.nix
+++ b/programs/biome.nix
@@ -43,7 +43,7 @@ in
     (mkFormatterModule {
       name = "biome";
       args = [
-        "format"
+        "check"
         "--write"
         "--no-errors-on-unmatched"
       ];
@@ -140,15 +140,14 @@ in
           };
         } // shared;
 
-        organizeImports = {
-          enabled = l.mkOption {
-            description = "Enables Biome’s sort imports.";
-            type = t.bool;
-            example = false;
-            default = true;
-          };
-
-          inherit (common) ignore include;
+        assist.actions.source.organizeImports = l.mkOption {
+          description = "Enables Biome’s sort imports.";
+          type = t.enum [
+            "on"
+            "off"
+          ];
+          example = "on";
+          default = "on";
         };
 
         javascript = {


### PR DESCRIPTION
This PR is meant to solve the issue mentioned here #378, about biome not sorting imports