### PR TITLE
Add `formatter.useEditorconfig` to Biome

### DIFF
--- a/programs/biome.nix
+++ b/programs/biome.nix
@@ -138,6 +138,13 @@ in
             example = true;
             default = false;
           };
+
+          useEditorconfig = l.mkOption {
+            description = "Whether Biome should use the .editorconfig file to determine the formatting options";
+            type = t.bool;
+            example = true;
+            default = false;
+          };
         } // shared;
 
         organizeImports = {


### PR DESCRIPTION
Title. The added option makes Biome respect editorconfig.
See https://biomejs.dev/reference/configuration/#formatteruseeditorconfig