### PR TITLE
feat: use json schema for biome

### DIFF
--- a/examples/formatter-biome.toml
+++ b/examples/formatter-biome.toml
@@ -18,4 +18,4 @@ includes = [
     "*.jsonc",
     "*.css",
 ]
-options = ["check", "--write", "--no-errors-on-unmatched"]
+options = ["check", "--write", "--no-errors-on-unmatched", "--config-path", "config"]

--- a/programs/biome.nix
+++ b/programs/biome.nix
@@ -13,6 +13,11 @@ let
   cfg = config.programs.biome;
   biomeVersion = if builtins.match "^1\\." pkgs.biome.version != null then "1.9.4" else "2.1.2";
   schemaUrl = "https://biomejs.dev/schemas/${biomeVersion}/schema.json";
+  schemaSha256s = {
+    "1.9.4" = "sha256:0yzw4vymwpa7akyq45v7kkb9gp0szs6zfm525zx2vh1d80568dlz";
+    "2.1.2" = "sha256:07qlk53lja9rsa46b8nv3hqgdzc9mif5r1nwh7i8mrxcqmfp99s2";
+  };
+  schemaSha256 = schemaSha256s.${biomeVersion};
 
   ext.js = [
     "*.js"
@@ -70,7 +75,7 @@ in
       default = false;
     };
     settings = l.mkOption {
-      type = t.attrs;
+      type = t.attrsOf t.anything;
       description = "Raw Biome configuration (must conform to Biome JSON schema)";
       default = { };
       example = {
@@ -100,12 +105,7 @@ in
         jsonFile = p.writeText "biome.json" json;
         biomeSchema = builtins.fetchurl {
           url = schemaUrl;
-          sha256 =
-            # Support both nixpkgs and nixpkgs-unstable
-            if biomeVersion == "1.9.4" then
-              "sha256:0yzw4vymwpa7akyq45v7kkb9gp0szs6zfm525zx2vh1d80568dlz"
-            else
-              "sha256:07qlk53lja9rsa46b8nv3hqgdzc9mif5r1nwh7i8mrxcqmfp99s2";
+          sha256 = schemaSha256;
         };
 
         validatedConfig =


### PR DESCRIPTION
I'm writing this PR because I noticed that the formatter is missing most of the options that Biome provides. I think it would be a lot easier for us if we didn't have to manually add our own options. Instead, I propose that we use free-field options and validate them against Biome's JSON schema.
I have also provided the option to set the command for biome and if it should process unsafe fixes.
I am not an expert of Nix, I tested locally and it is working correctly, but please let me know if any improvement is required