### PR TITLE
README: update systems input in flakes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ attribute:
 # flake.nix
 {
   inputs.treefmt-nix.url = "github:numtide/treefmt-nix";
+  inputs.systems.url = "github:nix-systems/default";
 
   outputs = { self, nixpkgs, systems, treefmt-nix }:
     let


### PR DESCRIPTION
It seems that the flake inputs in the documentation are missing [nix-systems/default](https://github.com/nix-systems/default) as an input for the flake. However, by referring to the implementation in [treefmt-nix/flake.nix](https://github.com/numtide/treefmt-nix/blob/main/flake.nix), I ultimately made the following change (as shown in the PR):

```nix
outputs = { self, nixpkgs, treefmt-nix }:
    let
      systems = [
        "aarch64-darwin"
        "aarch64-linux"
        "x86_64-darwin"
        "x86_64-linux"
      ];
      # Small tool to iterate over each systems
      eachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});

      # Eval the treefmt modules from ./treefmt.nix
      treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs ./treefmt.nix);
    in
    {
      # for `nix fmt`
      formatter = eachSystem (pkgs: treefmtEval.${pkgs.system}.config.build.wrapper);
      # for `nix flake check`
      checks = eachSystem (pkgs: {
        formatting = treefmtEval.${pkgs.system}.config.build.check self;
      });
    };
```