### PR TITLE
fix: biome config extension missing

### DIFF
--- a/examples/formatter-biome.toml
+++ b/examples/formatter-biome.toml
@@ -18,4 +18,4 @@ includes = [
     "*.jsonc",
     "*.css",
 ]
-options = ["check", "--write", "--no-errors-on-unmatched", "--config-path", "config"]
+options = ["check", "--write", "--no-errors-on-unmatched", "--config-path", "config.json"]

--- a/programs/biome.nix
+++ b/programs/biome.nix
@@ -109,7 +109,7 @@ in
         };
 
         validatedConfig =
-          p.runCommand "validated-biome-config"
+          p.runCommand "validated-biome-config.json"
             {
               buildInputs = [
                 p.check-jsonschema


### PR DESCRIPTION
Sorry, with the PR #391, I introduced an issue with biome v2+. The biome CLI refuses configuration if they do not have .json extension. 