### PR TITLE
fix(typos): run with '--force-exclude'

### DIFF
--- a/programs/typos.nix
+++ b/programs/typos.nix
@@ -13,7 +13,10 @@ in
   imports = [
     (mkFormatterModule {
       name = "typos";
-      args = [ "--write-changes" ];
+      args = [
+        "--write-changes"
+        "--force-exclude"
+      ];
       includes = [ "*" ];
     })
   ];


### PR DESCRIPTION
This commit forces typos to ignore files explicilty passed as cli arguments, if they would otherwise be ignored based on typos' config. Previously, treefmt could explicitly pass files to typos that typos should otherwise ignore, which is expected behavior to typos but is not desirable when working with treefmt.