### PR TITLE
feat: add dockerfmt formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ functions.
 <!-- `> bash ./supported-programs.sh` -->
 
 <!-- BEGIN mdsh -->
-`treefmt-nix` currently supports 111 formatters:
+`treefmt-nix` currently supports 112 formatters:
 
 * [actionlint](programs/actionlint.nix)
 * [alejandra](programs/alejandra.nix)
@@ -246,6 +246,7 @@ functions.
 * [deno](programs/deno.nix)
 * [dhall](programs/dhall.nix)
 * [dnscontrol](programs/dnscontrol.nix)
+* [dockerfmt](programs/dockerfmt.nix)
 * [dockfmt](programs/dockfmt.nix)
 * [dos2unix](programs/dos2unix.nix)
 * [dprint](programs/dprint.nix)

--- a/programs/dockerfmt.nix
+++ b/programs/dockerfmt.nix
@@ -1,0 +1,19 @@
+{ lib, mkFormatterModule, ... }:
+{
+  meta.maintainers = [ "bizmythy" ];
+  meta.brokenPlatforms = lib.platforms.darwin;
+
+  imports = [
+    (mkFormatterModule {
+      name = "dockerfmt";
+      args = [
+        "-w"
+        "-n"
+      ];
+      includes = [
+        "*/Dockerfile"
+        "*.dockerfile"
+      ];
+    })
+  ];
+}


### PR DESCRIPTION
Adds [dockerfmt](https://github.com/reteps/dockerfmt), "a modern version of dockfmt".

Adds `-n` and `-w` args to write the file with a newline ending instead of just printing formatting changes.

It was [recently added to nixpkgs](https://github.com/NixOS/nixpkgs/pull/428515), so I needed to update `flake.lock`