### PR TITLE
feat(ruff-check): extendSelect option

### DIFF
--- a/programs/ruff-check.nix
+++ b/programs/ruff-check.nix
@@ -1,4 +1,12 @@
-{ lib, mkFormatterModule, ... }:
+{
+  config,
+  lib,
+  mkFormatterModule,
+  ...
+}:
+let
+  cfg = config.programs.ruff-check;
+in
 {
   meta.maintainers = [ ];
 
@@ -32,4 +40,24 @@
       ];
     })
   ];
+
+  options.programs.ruff-check = {
+    extendSelect = lib.mkOption {
+      description = ''
+        --extend-select options
+      '';
+      type = lib.types.listOf lib.types.str;
+      example = [ "I" ];
+      default = [ ];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    settings.formatter.ruff-check = {
+      options = lib.optionals ((builtins.length cfg.extendSelect) != 0) [
+        "--extend-select"
+        (lib.concatStringsSep "," cfg.extendSelect)
+      ];
+    };
+  };
 }


### PR DESCRIPTION
adding support for `ruff-check` `--extend-select` options.

[Ruff Docs](https://docs.astral.sh/ruff/settings/#lint_extend-select)