### PR TITLE
Add `*.{slnx,xaml}` to csharpier's default `includes`

### DIFF
--- a/examples/formatter-csharpier.toml
+++ b/examples/formatter-csharpier.toml
@@ -2,5 +2,5 @@
 [formatter.csharpier]
 command = "csharpier"
 excludes = []
-includes = ["*.cs", "*.csproj"]
+includes = ["*.cs", "*.csproj", "*.slnx", "*.xaml"]
 options = ["format"]

--- a/programs/csharpier.nix
+++ b/programs/csharpier.nix
@@ -13,7 +13,8 @@
       includes = [
         "*.cs"
         "*.csproj"
-        # "*.slnx" # add this with 1.0.3 release
+        "*.slnx" # support added in 1.1.0
+        "*.xaml" # support added in 1.1.0
       ];
     })
   ];


### PR DESCRIPTION
Support for both filetypes was added upstream in https://github.com/belav/csharpier/pull/1648 and first released in csharpier 1.1.0.

This is a follow-up to [my comment on 369](https://github.com/numtide/treefmt-nix/pull/369#pullrequestreview-3145486687).