### PR TITLE
feat: auto update biome version

### DIFF
--- a/.github/workflows/update-biome.yml
+++ b/.github/workflows/update-biome.yml
@@ -1,0 +1,34 @@
+name: Update Biome Schemas
+on:
+  schedule:
+    - cron: "0 12 * * *" # Runs at 12:00 UTC every day
+  workflow_dispatch: # allow manual triggering
+jobs:
+  update-biome:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout repository
+      - name: Checkout repo
+        uses: actions/checkout@v5
+      # Setup nix
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_url: https://nixos.org/nix/install
+      # Run the update script
+      - name: Update Biome Schemas
+        run: |
+          chmod +x ./update-biome-versions.sh
+          ./update-biome-versions.sh
+      # Create PR (handles everything automatically)
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update Biome schema hashes
+          branch: update/biome-schemas
+          base: main
+          title: "Update Biome schema hashes"
+          body: "Automatically updated Biome schema hashes via scheduled workflow."
+          add-paths: |
+            programs/biome.nix

--- a/programs/biome.nix
+++ b/programs/biome.nix
@@ -11,12 +11,64 @@ let
   p = pkgs;
 
   cfg = config.programs.biome;
-  biomeVersion = if builtins.match "^1\\." pkgs.biome.version != null then "1.9.4" else "2.1.2";
-  schemaUrl = "https://biomejs.dev/schemas/${biomeVersion}/schema.json";
   schemaSha256s = {
+    "1.2.2" = "sha256:0fx7dwg1pya0m45vi8wymhndd8imas6mnd35maznbzk4ig69ffrf";
+    "1.3.0" = "sha256:0nl5651k3zyqz3rx81mi376h4k3mwgf1bx9sc3rmasm4i9h5h373";
+    "1.3.1" = "sha256:1wbyx743qn34xpdc2mmfi0vjbvff9pkg1f5q0g4q8ip2czgqqfw4";
+    "1.3.2" = "sha256:1s08nzwxkc8dkqkd75qb2lw0zvmkaqj2a8pmh0yalfkfl3wkp7yv";
+    "1.3.3" = "sha256:1s08nzwxkc8dkqkd75qb2lw0zvmkaqj2a8pmh0yalfkfl3wkp7yv";
+    "1.4.0" = "sha256:1c4dvy2ii6phs4afrsbkvd3srfyhjx6qd6vi1jxj05ilq9kayfjj";
+    "1.4.1" = "sha256:1c4dvy2ii6phs4afrsbkvd3srfyhjx6qd6vi1jxj05ilq9kayfjj";
+    "1.5.0" = "sha256:03m82yxdalibb78bsd12203dhwlzrndhw2q30yh7jn86s475g3gk";
+    "1.5.1" = "sha256:1jbmx26l2lj5gn0z4sxib8jh3nax8my4vwss777vn4jacskhanx2";
+    "1.5.2" = "sha256:0h2z9x2ys3i3cbjvklgqz62mzs2bh3rfw7hd2xjspn3pyi32bdrv";
+    "1.5.3" = "sha256:17gbsa7y9cs7ns1196rr1rxkvagli9qj6kq59yxj575cgq2pl4np";
+    "1.6.0" = "sha256:14sycfdj4rbh6wqsf9cvlkmw6s2c8kpxz7mn5aibplvrwjkaxmc0";
+    "1.6.1" = "sha256:0sdh9g8ii1ycbwqjsj89qp8s3c9rchghn2adkvajrl04z1pknxw2";
+    "1.6.2" = "sha256:0j9ymdpnzxgia36q4qf4wdaj7wq431g6s1y935rdkzqyal6m57vv";
+    "1.6.3" = "sha256:1j52qgk5jwx1ifaic9ssamb35rmg9azhzvlkjha2wpm9bcx7b1ca";
+    "1.6.4" = "sha256:07d5r5xc7b8zchcg66q0lmqfvzn8lhqk85ygznphdij6bqf5zvi8";
+    "1.7.0" = "sha256:09wflniz1djv3x1w9sbr9jz8zjk7db6knhff0yi5yqhnc2qbwa26";
+    "1.7.1" = "sha256:0h4nchb4gymzmz4c22ckclf3vljkka6j7rpdsplwxzyh31nfi8l6";
+    "1.7.2" = "sha256:08qgr0fccj0i4k1037cq8xbxlqbgd05q26h3wj8jiq4n94dn1ddw";
+    "1.7.3" = "sha256:12qyzyzx74r1m4w56q0mj5d9kkl7jq6cmn2lzrmg83s4vwb8cgay";
+    "1.8.0" = "sha256:0d0wwvb9lvgfzpsyb4g0dcdqfgrw7v11f1g869g30smfq1y1daqx";
+    "1.8.1" = "sha256:0bhp7xhpjciiqyx3nbqqqgxi705k1767ikadkxky483ipa5m4wik";
+    "1.8.2" = "sha256:01b4qr0aql8vm1g63nc56hybzsc36f3ws91zr8vmwyb4pzm8cksl";
+    "1.8.3" = "sha256:0sbzlbdlx6gijw2wk5n0x9lx5zz93sm5fhrxm2z64hhvp8kscr43";
+    "1.9.0" = "sha256:1whq6jv40jfzxjpxy9knqx9fwiajb6mgfcjd2ypr2r8nvfill0jp";
+    "1.9.1" = "sha256:1c1201h3lal8gqig15cqnrayd1dqf64xkk3nhhzlhkvqhjy6kwn1";
+    "1.9.2" = "sha256:098pz1klkh752mnpq8hhw47l09a194xhadfhmb7xjfjps4gcz97g";
+    "1.9.3" = "sha256:1ww2by73b8csa3haphjxv4j10rk5hzsw8kgwgmb4axrqmxhvnrga";
     "1.9.4" = "sha256:0yzw4vymwpa7akyq45v7kkb9gp0szs6zfm525zx2vh1d80568dlz";
+    "2.0.0" = "sha256:17rz3kswhlqns04cff55sdmkgy6q9klxa3r16m4wssfs8cwcqnzy";
+    "2.0.4" = "sha256:1bc690175l9s4knalqpmrss1wagc4v7dwh0nmjgajkfm7h46z6qk";
+    "2.0.5" = "sha256:1bc690175l9s4knalqpmrss1wagc4v7dwh0nmjgajkfm7h46z6qk";
+    "2.0.6" = "sha256:122v3c1w037mwmbil83l1yhhxissl5gp07qyyrkml7hfc8wraavf";
+    "2.1.0" = "sha256:0r5fcvlpdal1zc32nhcslicp2jmr0bhlrnmr5xlhwrjdknbb5hxk";
+    "2.1.1" = "sha256:0r5fcvlpdal1zc32nhcslicp2jmr0bhlrnmr5xlhwrjdknbb5hxk";
     "2.1.2" = "sha256:07qlk53lja9rsa46b8nv3hqgdzc9mif5r1nwh7i8mrxcqmfp99s2";
+    "2.1.3" = "sha256:03sr8wfwjk8yww7ai7sics8p32bh4f760pzzxzcqllv6npy6kcpk";
+    "2.1.4" = "sha256:10slb3g26lbrmid424xnrcr23fyyzx1n4189xymxw0ys4bl8743l";
+    "2.2.0" = "sha256:15hwjj1bmsp6pa9rmj4l73n247g4cssh0fy443bk1pafcz3ns18j";
   };
+  allVersions = builtins.attrNames schemaSha256s;
+  biomeVersion =
+    if (pkgs.biome.version != null && builtins.elem pkgs.biome.version allVersions) then
+      pkgs.biome.version
+    else
+      let
+        targetVersion = pkgs.biome.version or "0.0.0";
+        findClosestVersion =
+          target: versions:
+          let
+            sortedVersions = builtins.sort lib.versionOlder versions;
+            suitableVersions = builtins.filter (v: builtins.compareVersions v target <= 0) sortedVersions;
+          in
+          if suitableVersions != [ ] then lib.last suitableVersions else builtins.head sortedVersions;
+      in
+      findClosestVersion targetVersion allVersions;
+  schemaUrl = "https://biomejs.dev/schemas/${biomeVersion}/schema.json";
   schemaSha256 = schemaSha256s.${biomeVersion};
 
   ext.js = [

--- a/update-biome-versions.sh
+++ b/update-biome-versions.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILE="programs/biome.nix"
+
+# ---- cross-platform sed in-place helper ----
+sedi() {
+  local sed_expr="$1"
+  local file="$2"
+  if sed --version >/dev/null 2>&1; then
+    # GNU sed
+    sed -i "$sed_expr" "$file"
+  else
+    # BSD/macOS sed
+    sed -i '' "$sed_expr" "$file"
+  fi
+}
+
+# ---- get stable and unstable Biome versions from nixpkgs ----
+get_biome_version() {
+  local ref=$1
+  nix eval --raw "github:NixOS/nixpkgs/$ref#biome.version"
+}
+
+get_nixos_stable_tag() {
+  git ls-remote --tags https://github.com/NixOS/nixpkgs.git |
+    awk '{print $2}' |
+    grep -E 'refs/tags/[0-9]+\.[0-9]+$' |
+    sed 's|refs/tags/||' |
+    sort -V |
+    tail -n1
+}
+
+STABLE_VERSION=$(get_biome_version "$(get_nixos_stable_tag)")
+UNSTABLE_VERSION=$(get_biome_version "nixos-unstable")
+
+# ---- deduplicate version list ----
+mapfile -t VERSION_LIST < <(printf "%s\n" "$STABLE_VERSION" "$UNSTABLE_VERSION" | sort -u)
+echo "Versions to check: ${VERSION_LIST[*]}"
+
+# ---- extract existing schemaSha256s block into TMP_ENTRIES ----
+TMP_ENTRIES="$(mktemp)"
+awk '
+/^[[:space:]]*schemaSha256s = {/{flag=1; next}
+/^[[:space:]]*};/{flag=0; next}
+flag && /^[[:space:]]*"/ {print}
+' "$FILE" | sed 's/["=;]//g' | awk '{print $1, $2}' >"$TMP_ENTRIES" || true
+
+# ---- helper functions ----
+version_known() {
+  local v="$1"
+  grep -q "^$v " "$TMP_ENTRIES"
+}
+
+schema_exists() {
+  local v="$1"
+  local url="https://biomejs.dev/schemas/${v}/schema.json"
+  curl -fsL -o /dev/null "$url"
+}
+
+# ---- add missing versions to TMP_ENTRIES ----
+for v in "${VERSION_LIST[@]}"; do
+  if version_known "$v"; then
+    echo "⚡ already recorded: $v"
+    continue
+  fi
+
+  if schema_exists "$v"; then
+    echo "✅ found: $v — prefetching hash..."
+    sha=$(nix-prefetch-url --quiet --type sha256 "https://biomejs.dev/schemas/${v}/schema.json")
+    echo "$v sha256:$sha" >>"$TMP_ENTRIES"
+  else
+    echo "❌ schema not found for $v"
+  fi
+done
+
+# ---- sort all entries ----
+sort -V "$TMP_ENTRIES" -o "$TMP_ENTRIES"
+
+# ---- rebuild schemaSha256s block in the file ----
+TMP_FILE="$(mktemp)"
+awk -v entries="$TMP_ENTRIES" '
+  BEGIN { while ((getline < entries) > 0) { e[++n] = $0 } }
+  /^[[:space:]]*schemaSha256s = {/,/^[[:space:]]*};/ {
+      if ($0 ~ /^[[:space:]]*schemaSha256s = {/) {
+          print $0
+          for (i=1;i<=n;i++) {
+              split(e[i], a, " ")
+              printf "    \"%s\" = \"%s\";\n", a[1], a[2]
+          }
+          next
+      }
+      if ($0 ~ /^[[:space:]]*};/) { print $0; next }
+      next
+  }
+  { print }
+' "$FILE" >"$TMP_FILE"
+
+mv "$TMP_FILE" "$FILE"
+rm "$TMP_ENTRIES"
+
+echo "✨ Updated schemaSha256s in $FILE"


### PR DESCRIPTION
The purpose of this PR is to automatically create PR to keep biome hashes updated. 
### What this PR does:

- Biome now store all hashes for the related schema, so it will be compatible if whatever nixpkgs user has
- New script to automatically retrieve newest versions of biome schema, and automatically update [https://github.com/numtide/treefmt-nix/blob/main/programs/biome.nix](biome.nix)
- GitHub action running every day to check if a new biome is available and create a PR if so (it takes around 1 minute: [Test build](https://github.com/hackardoX/treefmt-nix/actions/runs/17195210282) ). Resulting in a [PR created by GitHub Bot](https://github.com/hackardoX/treefmt-nix/pull/1) 

### Tests

- [x] Tested locally in other flakes