### PR TITLE
nixfmt-classic: remove warning

### DIFF
--- a/programs/nixfmt-classic.nix
+++ b/programs/nixfmt-classic.nix
@@ -1,12 +1,4 @@
-{
-  lib,
-  config,
-  mkFormatterModule,
-  ...
-}:
-let
-  cfg = config.programs.nixfmt-classic;
-in
+{ mkFormatterModule, ... }:
 {
   meta.maintainers = [ ];
 
@@ -16,16 +8,4 @@ in
       includes = [ "*.nix" ];
     })
   ];
-
-  config = lib.mkIf cfg.enable {
-    settings.formatter.nixfmt-classic = (
-      lib.warn ''
-        nixfmt-classic is the original flavor of 'nixfmt'.
-        This version differs considerably from the new standard and is currently
-        unmaintained.
-        It has been superseded by 'nixfmt', which conforms to the
-        'nixfmt-rfc-style' standard.
-      '' { }
-    );
-  };
 }


### PR DESCRIPTION
I found it annoying to always have this warning especially as I'm already explicitly opting to use this formatter and I thought that it would just add extra clutter to have an option to disable the warning