### PR TITLE
typstyle: add indentWidth, lineWidth, wrapText options

### DIFF
--- a/programs/typstyle.nix
+++ b/programs/typstyle.nix
@@ -1,4 +1,12 @@
-{ mkFormatterModule, ... }:
+{
+  lib,
+  config,
+  mkFormatterModule,
+  ...
+}:
+let
+  cfg = config.programs.typstyle;
+in
 {
   meta.maintainers = [ "SigmaSquadron" ];
 
@@ -12,4 +20,38 @@
       ];
     })
   ];
+
+  options.programs.typstyle = with lib; {
+    indentWidth = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = 4;
+      description = ''
+        Number of spaces per indent level (default: 2).
+      '';
+    };
+    lineWidth = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = 100;
+      description = ''
+        Maximum line width in characters (default: 80).
+      '';
+    };
+    wrapText = mkEnableOption "line wrapping of markup text";
+  };
+
+  config = lib.mkIf cfg.enable {
+    settings.formatter.typstyle.options =
+      lib.optional cfg.wrapText "--wrap-text"
+      ++ lib.optionals (!isNull cfg.lineWidth) [
+        "--line-width"
+        (toString cfg.lineWidth)
+      ]
+      ++ lib.optionals (!isNull cfg.indentWidth) [
+        "--indent-width"
+        (toString cfg.indentWidth)
+      ];
+  };
+
 }


### PR DESCRIPTION
These options correspond to command-line options added in v0.13.7 of `typstyle` (0.13.4 for `--wrap-text`). I have tested them on a dummy Typst file and they seem to function as expected.