### PR TITLE
sqlfluff: Add option for configFile

### DIFF
--- a/programs/sqlfluff.nix
+++ b/programs/sqlfluff.nix
@@ -46,6 +46,10 @@ in
         "--disable-progress-bar"
         "--processes"
         "0"
+      ]
+      ++ lib.optionals (cfg.configFile != null) [
+        "--config"
+        "${cfg.configFile}"
       ];
       includes = [ "*.sql" ];
     })
@@ -57,6 +61,12 @@ in
       type = with lib.types; nullOr (enum dialects);
       default = null;
       example = "sqlite";
+    };
+
+    configFile = lib.mkOption {
+      description = "The config file to pass when formatting";
+      type = lib.types.nullOr lib.types.path;
+      default = null;
     };
   };
 


### PR DESCRIPTION
I confirmed that this works as expected.

If someone tells me how to also add a configuration option that can be used from within nix without mapping all [config options sqlfluff has](https://docs.sqlfluff.com/en/stable/configuration/default_configuration.html) to nix options by hand, I'd love to do that.

For now, this works for me.