### PR TITLE
feat(shfmt): add simplify option

### DIFF
--- a/examples/formatter-shfmt.toml
+++ b/examples/formatter-shfmt.toml
@@ -3,4 +3,4 @@
 command = "shfmt"
 excludes = []
 includes = ["*.sh", "*.bash", "*.envrc", "*.envrc.*"]
-options = ["-s", "-w", "-i", "2"]
+options = ["-w", "-i", "2", "-s"]

--- a/programs/shfmt.nix
+++ b/programs/shfmt.nix
@@ -17,10 +17,7 @@ in
   imports = [
     (mkFormatterModule {
       name = "shfmt";
-      args = [
-        "-s"
-        "-w"
-      ];
+      args = [ "-w" ];
       includes = [
         "*.sh"
         "*.bash"
@@ -42,12 +39,22 @@ in
         shfmt](https://github.com/patrickvane/shfmt#description).
       '';
     };
+
+    simplify = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Enables the `-s` (`--simplify`) flag, which simplifies code where possible.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
-    settings.formatter.shfmt.options = lib.optionals (!isNull cfg.indent_size) [
-      "-i"
-      (toString cfg.indent_size)
-    ];
+    settings.formatter.shfmt.options =
+      (lib.optionals (!isNull cfg.indent_size) [
+        "-i"
+        (toString cfg.indent_size)
+      ])
+      ++ (lib.optionals (cfg.simplify) [ "-s" ]);
   };
 }


### PR DESCRIPTION
Adding support for `-s` (`--simplify`) flag in shfmt.

`true` by default to avoid breaking change.

https://man.archlinux.org/man/extra/shfmt/shfmt.1.en#Parser_flags