### PR TITLE
nixfmt: indent option

### DIFF
--- a/programs/nixfmt.nix
+++ b/programs/nixfmt.nix
@@ -53,6 +53,10 @@ in
         "--width"
         (toString cfg.width)
       ]
+      ++ lib.optionals (!isNull cfg.indent) [
+        "--indent"
+        (toString cfg.indent)
+      ]
       ++ lib.optional cfg.strict "--strict";
   };
 }


### PR DESCRIPTION
resolves #389

just a mirror from width option. tested locally in a flake via input overriding

aside from this feature, statix screamed at me that `isNull` is deprecated. after this pr, i would like to make an another one with slight refactoring:

- use `with lib.types` for types, i think `with lib.types; nullOr int` is more readable
- remove `isNull` with plain null check