### PR TITLE
tree-wide: add NixOS/nixpkgs-ci maintainers

### DIFF
--- a/programs/biome.nix
+++ b/programs/biome.nix
@@ -45,7 +45,10 @@ let
 
 in
 {
-  meta.maintainers = [ "andrea11" ];
+  meta.maintainers = [
+    "NixOS/nixpkgs-ci"
+    "andrea11"
+  ];
 
   imports = [
     (mkFormatterModule {

--- a/programs/keep-sorted.nix
+++ b/programs/keep-sorted.nix
@@ -1,6 +1,9 @@
 { mkFormatterModule, ... }:
 {
-  meta.maintainers = [ "katexochen" ];
+  meta.maintainers = [
+    "NixOS/nixpkgs-ci"
+    "katexochen"
+  ];
 
   imports = [
     (mkFormatterModule {

--- a/programs/nixf-diagnose.nix
+++ b/programs/nixf-diagnose.nix
@@ -1,6 +1,8 @@
 { mkFormatterModule, ... }:
 {
-  meta.maintainers = [ ];
+  meta.maintainers = [
+    "NixOS/nixpkgs-ci"
+  ];
 
   imports = [
     (mkFormatterModule {

--- a/programs/nixfmt.nix
+++ b/programs/nixfmt.nix
@@ -8,7 +8,9 @@ let
   cfg = config.programs.nixfmt;
 in
 {
-  meta.maintainers = [ ];
+  meta.maintainers = [
+    "NixOS/nixpkgs-ci"
+  ];
 
   imports = [
     (mkFormatterModule {

--- a/programs/yamlfmt.nix
+++ b/programs/yamlfmt.nix
@@ -11,7 +11,9 @@ let
   settingsFormat = pkgs.formats.yaml { };
 in
 {
-  meta.maintainers = [ ];
+  meta.maintainers = [
+    "NixOS/nixpkgs-ci"
+  ];
 
   imports = [
     (mkFormatterModule {

--- a/programs/zizmor.nix
+++ b/programs/zizmor.nix
@@ -1,6 +1,9 @@
 { lib, mkFormatterModule, ... }:
 {
-  meta.maintainers = [ "katexochen" ];
+  meta.maintainers = [
+    "NixOS/nixpkgs-ci"
+    "katexochen"
+  ];
   meta.brokenPlatforms = lib.platforms.darwin;
 
   imports = [


### PR DESCRIPTION
Add it to all the packages used by nixpkgs, so we can be a bit more careful before merging those.

See the usage on the other side:
https://github.com/NixOS/nixpkgs/blob/c66477f29605a9832aa48ca45c3bae4fca1d6976/ci/default.nix#L33