### PR TITLE
fix(various): don't include empty config

### DIFF
--- a/examples/formatter-biome.toml
+++ b/examples/formatter-biome.toml
@@ -18,4 +18,4 @@ includes = [
     "*.jsonc",
     "*.css",
 ]
-options = ["check", "--write", "--no-errors-on-unmatched", "--config-path", "config.json"]
+options = ["check", "--write", "--no-errors-on-unmatched"]

--- a/examples/formatter-genemichaels.toml
+++ b/examples/formatter-genemichaels.toml
@@ -3,4 +3,4 @@
 command = "genemichaels"
 excludes = []
 includes = ["*.rs"]
-options = ["--config", "genemichaels.json"]
+options = []

--- a/examples/formatter-php-cs-fixer.toml
+++ b/examples/formatter-php-cs-fixer.toml
@@ -3,4 +3,4 @@
 command = "php-cs-fixer"
 excludes = []
 includes = ["*.php"]
-options = ["fix", "--config", "./.php-cs-fixer.php"]
+options = ["fix"]

--- a/programs/biome.nix
+++ b/programs/biome.nix
@@ -159,7 +159,7 @@ in
               cp "$json" $out
             '';
       in
-      [
+      l.optionals (cfg.settings != { }) [
         "--config-path"
         "${if cfg.validate.enable then validatedConfig else jsonFile}"
       ]

--- a/programs/genemichaels.nix
+++ b/programs/genemichaels.nix
@@ -7,6 +7,7 @@
 }:
 let
   cfg = config.programs.genemichaels;
+  opt = options.programs.genemichaels;
   configFormat = pkgs.formats.json { };
 
   inherit (lib)
@@ -123,10 +124,14 @@ in
 
     settingsFile = mkOption {
       description = "The configuration file used by `genemichaels`.";
-      type = types.path;
+      type = types.nullOr types.path;
       example = lib.literalExpression "./.genemichaels.json";
-      default = configFormat.generate ".genemichaels.json" cfg.settings;
-      defaultText = lib.literalMD "Generated JSON file from `${showOptionParent options.programs.genemichaels.settings.max_width 1}`";
+      default =
+        let
+          settings = lib.filterAttrs (key: value: value != opt.settings.${key}.default) cfg.settings;
+        in
+        if settings != { } then configFormat.generate ".genemichaels.json" settings else null;
+      defaultText = lib.literalMD "Generated JSON file from `${showOptionParent opt.settings.max_width 1}`";
     };
 
     threadCount = mkOption {
@@ -166,10 +171,10 @@ in
           "--thread-count"
           (toString cfg.threadCount)
         ])
-        ++ [
+        ++ (optionals (cfg.settingsFile != null) [
           "--config"
           (toString cfg.settingsFile)
-        ];
+        ]);
       includes = cfg.includes;
       excludes = cfg.excludes;
     };

--- a/programs/php-cs-fixer.nix
+++ b/programs/php-cs-fixer.nix
@@ -26,18 +26,15 @@ in
   options.programs.php-cs-fixer = {
     configFile = lib.mkOption {
       description = "Path to php-cs-fixer config file.";
-      type = types.oneOf [
-        types.str
-        types.path
-      ];
-      default = "./.php-cs-fixer.php";
-      example = "./.php-cs-fixer.dist.php";
+      type = types.nullOr (types.pathWith { });
+      default = null;
+      example = lib.literalExpression "./.php-cs-fixer.dist.php";
     };
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.php-cs-fixer = {
-      options = [
+      options = lib.optionals (cfg.configFile != null) [
         "--config"
         "${cfg.configFile}"
       ];

--- a/programs/statix.nix
+++ b/programs/statix.nix
@@ -43,7 +43,9 @@ in
       # statix doesn't support multiple file targets
       command = pkgs.writeShellScriptBin "statix-fix" ''
         for file in "$@"; do
-          ${lib.getExe cfg.package} fix --config '${toString settingsDir}/statix.toml' "$file"
+          ${lib.getExe cfg.package} fix ${
+            lib.optionalString (cfg.disabled-lints != [ ]) "--config '${settingsDir}/statix.toml'"
+          } "$file"
         done
       '';
     };


### PR DESCRIPTION
Some formatters generate config files with default/no settings. This change will allow using an in-tree config file with those formatters as well (for example, when one wants identical formatting in Treefmt and their editor)