### PR TITLE
biome: allow overriding config path

### DIFF
--- a/programs/biome.nix
+++ b/programs/biome.nix
@@ -171,11 +171,11 @@ in
             '';
       in
       [ ]
-      ++ l.optional (cfg.configPath != null) [
+      ++ l.optionals (cfg.configPath != null) [
         "--config-path"
         "${cfg.configPath}"
       ]
-      ++ l.optional (cfg.configPath == null) [
+      ++ l.optionals (cfg.configPath == null) [
         "--config-path"
         "${if cfg.validate.enable then validatedConfig else jsonFile}"
       ]


### PR DESCRIPTION
It's currently not possible to use plugins because the `extends` attribute is evaluated relative to the configuration file, not the current working directory.

The current implementation generates the file and doesn't allow overriding the path, so the configuration file is always located at `/nix/store/...`. Consequently, the path to any plugin or other relative path in the `extends` attribute will always be incorrect.

This PR also introduces support for a more recent version of biome.