### PR TITLE
feat(shfmt): add a `useEditorConfig` option

### DIFF
--- a/programs/shfmt.nix
+++ b/programs/shfmt.nix
@@ -31,30 +31,40 @@ in
   options.programs.shfmt = {
     indent_size = lib.mkOption {
       type = lib.types.nullOr lib.types.int;
-      default = 2;
+      default = if cfg.useEditorConfig then null else 2;
       example = 4;
       description = ''
         Sets the number of spaces to be used in indentation. Uses tabs if set to
-        zero. If this is null, then [.editorconfig will be used to configure
-        shfmt](https://github.com/patrickvane/shfmt#description).
+        zero.
       '';
     };
 
     simplify = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = !cfg.useEditorConfig;
       description = ''
         Enables the `-s` (`--simplify`) flag, which simplifies code where possible.
       '';
     };
+
+    useEditorConfig = lib.mkEnableOption ''
+      Use .editorconfig file for
+      formatting. This is mutually exlusive with all other settings. See [shfmt
+      docs](https://github.com/mvdan/sh/blob/v3.12.0/cmd/shfmt/shfmt.1.scd?plain=1#L20-L21).
+    '';
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.shfmt.options =
-      (lib.optionals (!isNull cfg.indent_size) [
-        "-i"
-        (toString cfg.indent_size)
-      ])
-      ++ (lib.optionals (cfg.simplify) [ "-s" ]);
+      let
+        options =
+          (lib.optionals (!isNull cfg.indent_size) [
+            "-i"
+            (toString cfg.indent_size)
+          ])
+          ++ (lib.optionals (cfg.simplify) [ "-s" ]);
+      in
+      assert cfg.useEditorConfig -> builtins.length options == 0;
+      options;
   };
 }


### PR DESCRIPTION
With vanilla `shfmt`, it's easy to get it to use `.editorconfig` files: you simply [invoke it with no
arguments](https://github.com/mvdan/sh/blob/v3.12.0/cmd/shfmt/shfmt.1.scd?plain=1#L20-L21).

However, with `treefmt-nix`, it's a bit more challenging because we turn on some knobs by default, and those knobs change over time. For example, we have users who [used to accomplish this by setting `indent_size` to `null`](https://github.com/sellout/bash-strict-mode/blob/37eaa2e33d24168e0a903ddd9828666c1b91f867/.config/project/default.nix#L31-L33), but then we recently added the [simplify flag which defaults to true](https://github.com/numtide/treefmt-nix/commit/6b850bab259649cfcb25a54280ca4c0b42a40358), thereby causing shfmt to no longer honor `.editorconfig` files.

To give people some stability, this new `useEditorConfig` option changes the defaults so they're all disabled, and furthermore asserts that every option is disabled (in case people try to change them by hand). This protects our users against new default options in the future.

An alternative to this would be a policy of not deviating from shfmt's defaults, but I think this is clearer for everyone.