### PR TITLE
feat(prettier): add freeform type

### DIFF
--- a/programs/prettier.nix
+++ b/programs/prettier.nix
@@ -333,7 +333,14 @@ in
 
   options.programs.prettier = {
     # Represents the prettierrc.json config schema
-    settings = settingsSchema;
+    settings = mkOption {
+      default = { };
+      type = types.submodule {
+        # Allow freeform values to allow for plugin settings.
+        freeformType = configFormat.type;
+        options = settingsSchema;
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {


### PR DESCRIPTION
Adds a `freeformType` for the prettier module to fall back to, allowing for direct plugin configuration.

Fixes #381