### PR TITLE
mdsh: run on all Markdown files

### DIFF
--- a/examples/formatter-mdsh.toml
+++ b/examples/formatter-mdsh.toml
@@ -2,5 +2,5 @@
 [formatter.mdsh]
 command = "mdsh"
 excludes = []
-includes = ["README.md"]
+includes = ["*.md"]
 options = ["--inputs"]

--- a/programs/mdsh.nix
+++ b/programs/mdsh.nix
@@ -6,7 +6,7 @@
     (mkFormatterModule {
       name = "mdsh";
       args = [ "--inputs" ];
-      includes = [ "README.md" ];
+      includes = [ "*.md" ];
     })
   ];
 }


### PR DESCRIPTION
Change the includes pattern from README.md to *.md to format all Markdown files in the project.

Blocked until Nixpkgs includes https://github.com/zimbatm/mdsh/pull/93