### PR TITLE
fix(dprint): fix file include pattern to include all files

### DIFF
--- a/examples/formatter-dprint.toml
+++ b/examples/formatter-dprint.toml
@@ -2,5 +2,5 @@
 [formatter.dprint]
 command = "dprint"
 excludes = []
-includes = [".*"]
+includes = ["*"]
 options = ["fmt"]

--- a/programs/dprint.nix
+++ b/programs/dprint.nix
@@ -140,7 +140,7 @@ in
     (mkFormatterModule {
       name = "dprint";
       args = [ "fmt" ];
-      includes = [ ".*" ];
+      includes = [ "*" ];
     })
   ];
 


### PR DESCRIPTION
Instead of only hidden files. The problem was probably introduced while migrating to `mkFormatterModule`.

Currenty, when using the dpint program, it fails with:
```
No files found to format with the specified plugins at /home/(removed). You may want to try using `dprint output-file-paths` to see which files it's finding or run with `--allow-no-files`.
```