### PR TITLE
fix: added include patterns for the Dockerfiles formatters

### DIFF
--- a/examples/formatter-dockfmt.toml
+++ b/examples/formatter-dockfmt.toml
@@ -2,5 +2,14 @@
 [formatter.dockfmt]
 command = "dockfmt"
 excludes = []
-includes = ["Dockerfile", "*.Dockerfile", "Dockerfile.*"]
+includes = [
+    "Dockerfile",
+    "*/Dockerfile",
+    "*.Dockerfile",
+    "Dockerfile.*",
+    "*/Dockerfile.*",
+    "*.dockerfile",
+    "dockerfile.*",
+    "*/dockerfile.*",
+]
 options = ["fmt", "-w"]

--- a/programs/dockerfmt.nix
+++ b/programs/dockerfmt.nix
@@ -11,8 +11,14 @@
         "-n"
       ];
       includes = [
+        "Dockerfile"
         "*/Dockerfile"
+        "*.Dockerfile"
+        "Dockerfile.*"
+        "*/Dockerfile.*"
         "*.dockerfile"
+        "dockerfile.*"
+        "*/dockerfile.*"
       ];
     })
   ];

--- a/programs/dockfmt.nix
+++ b/programs/dockfmt.nix
@@ -11,8 +11,13 @@
       ];
       includes = [
         "Dockerfile"
+        "*/Dockerfile"
         "*.Dockerfile"
         "Dockerfile.*"
+        "*/Dockerfile.*"
+        "*.dockerfile"
+        "dockerfile.*"
+        "*/dockerfile.*"
       ];
     })
   ];


### PR DESCRIPTION
In this PR I add include patterns for the Dockerfiles formatters `dockfmt` and `dockerfmt`.