### PR TITLE
chore(biome): support 2.3.6 schema

### DIFF
--- a/programs/biome.nix
+++ b/programs/biome.nix
@@ -14,10 +14,18 @@ let
 
   cfg = config.programs.biome;
   opts = options.programs.biome;
-  biomeVersion = if builtins.match "^1\\." pkgs.biome.version != null then "1.9.4" else "2.1.2";
+  biomeVersion =
+    if builtins.match "^1\\." pkgs.biome.version != null then
+      "1.9.4"
+    else if builtins.match "^2\\.3\\." pkgs.biome.version != null then
+      "2.3.6"
+    else
+      "2.1.2";
+
   schemaHashes = {
     "1.9.4" = "sha256-SkkULLRk4CQzk+j0h8PAqOY6vGOrdG5ja7Z/tSAAKnY=";
     "2.1.2" = "sha256-n4Y16J7g34e0VdQzRItu/P7n5oppkY4Vm4P1pQxOILU=";
+    "2.3.6" = "sha256-eBBUomh9qBkl47tp73vsgWeOPZdVVGR3CAQ5eBs8eNw=";
   };
 
   ext.js = [


### PR DESCRIPTION
Adds support for 2.3.6's schema (current `biome` in nixpkgs). I was unsure on if we should prefer not breaking backwards compatibility here or prefer defaulting to a newer schema. Feel free to adjust the PR as needed
