### PR TITLE
chore: 124 formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ functions.
 <!-- `> bash ./supported-programs.sh` -->
 
 <!-- BEGIN mdsh -->
-`treefmt-nix` currently supports 123 formatters:
+`treefmt-nix` currently supports 124 formatters:
 
 * [actionlint](programs/actionlint.nix)
 * [aiken](programs/aiken.nix)


### PR DESCRIPTION
[this pr ](https://github.com/numtide/treefmt-nix/pull/456) and [this pr ](https://github.com/numtide/treefmt-nix/pull/452) had both passed ci and then were merged without rerunning checks. 
i am assuming that checks are set up to check if `nix fmt` has no output (which would have caught this if the checks of the second pr were rerun after merging the first) but since there's no merge queue and i'm guessing `Require branches to be up to date before merging` is not enabled (under `Require status checks to pass` in branch protection rules) the incorrect formatters number was able to go in.
not the biggest deal, but thought i would bring this to your attention.