### PR TITLE
fix: remove `*.toml` pattern from `oxfmt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ functions.
 <!-- `> bash ./supported-programs.sh` -->
 
 <!-- BEGIN mdsh -->
-`treefmt-nix` currently supports 121 formatters:
+`treefmt-nix` currently supports 122 formatters:
 
 * [actionlint](programs/actionlint.nix)
 * [aiken](programs/aiken.nix)

--- a/examples/formatter-oxfmt.toml
+++ b/examples/formatter-oxfmt.toml
@@ -18,7 +18,6 @@ includes = [
     "*.mjs",
     "*.mustache",
     "*.scss",
-    "*.toml",
     "*.ts",
     "*.tsx",
     "*.vue",

--- a/programs/oxfmt.nix
+++ b/programs/oxfmt.nix
@@ -21,7 +21,6 @@
         "*.mjs"
         "*.mustache"
         "*.scss"
-        "*.toml"
         "*.ts"
         "*.tsx"
         "*.vue"


### PR DESCRIPTION
The docs imply that `oxfmt` will format TOML files, but when I run it on a larger project that contains them, it errors out.

This commit removes '*.toml' from the file type list.