### PR TITLE
clang-tidy: allow compileCommandsPath to be relative

### DIFF
--- a/programs/clang-tidy.nix
+++ b/programs/clang-tidy.nix
@@ -41,7 +41,7 @@ in
       example = "/some/path/myTidyConfigFile";
     };
     compileCommandsPath = lib.mkOption {
-      type = lib.types.nullOr lib.types.path;
+      type = with lib.types; nullOr (either path str);
       description = "used to read a compile command database";
       default = null;
       example = "/my/cmake/build/directory";


### PR DESCRIPTION
Because `compileCommandsPath` requires `lib.types.path` I have to specify an absolute path, and that does not scale well.

E.g. If someone else checks out the project in a different location: My `build` directory could be in `/home/marijan/myproj/build`, a colleague could have theirs in `/home/colleague/workspace/myproj-1/build`.

Using Nix native paths also doesn't scale well e.g. `compileCommandsPath = ./build` would copy the entire build directory to the nix store.