### PR TITLE
feat(projectRootFile): allow native root detection

### DIFF
--- a/module-options.nix
+++ b/module-options.nix
@@ -143,9 +143,10 @@ in
       description = ''
         File to look for to determine the root of the project in the
         build.wrapper.
+        Set to null to let treefmt use its native detection.
       '';
       default = ".git/config";
-      type = types.str;
+      type = types.nullOr types.str;
     };
 
     enableDefaultExcludes = mkOption {
@@ -234,7 +235,14 @@ in
         default =
           let
             code =
-              if builtins.compareVersions "2.0.0-rc4" config.package.version == 1 then
+              if config.projectRootFile == null then
+                ''
+                  set -euo pipefail
+                  exec ${config.package}/bin/treefmt \
+                    --config-file=${config.build.configFile} \
+                    "$@"
+                ''
+              else if builtins.compareVersions "2.0.0-rc4" config.package.version == 1 then
                 ''
                   set -euo pipefail
                   find_up() {


### PR DESCRIPTION
`treefmt-nix` always passes --tree-root-file to treefmt,
which prevents `treefmt` from using its native tree root
detection.

When projectRootFile is set to null, omit `--tree-root-file`
entirely and let `treefmt` detect the tree root itself.


I chose `null` here to be backwards compatible.


Unresolved: I am not sure If I should unset `PRJ_ROOT` here.