### PR TITLE
biome: use schema output

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770107345,
-        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
+        "lastModified": 1778794387,
+        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
+        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
         "type": "github"
       },
       "original": {

--- a/programs/biome.nix
+++ b/programs/biome.nix
@@ -14,19 +14,6 @@ let
 
   cfg = config.programs.biome;
   opts = options.programs.biome;
-  biomeVersion =
-    if builtins.match "^1\\." pkgs.biome.version != null then
-      "1.9.4"
-    else if builtins.match "^2\\.3\\." pkgs.biome.version != null then
-      "2.3.6"
-    else
-      "2.1.2";
-
-  schemaHashes = {
-    "1.9.4" = "sha256-SkkULLRk4CQzk+j0h8PAqOY6vGOrdG5ja7Z/tSAAKnY=";
-    "2.1.2" = "sha256-n4Y16J7g34e0VdQzRItu/P7n5oppkY4Vm4P1pQxOILU=";
-    "2.3.6" = "sha256-eBBUomh9qBkl47tp73vsgWeOPZdVVGR3CAQ5eBs8eNw=";
-  };
 
   ext.js = [
     "*.js"
@@ -108,30 +95,11 @@ in
         };
       };
     };
-    validate = {
-      enable = l.mkOption {
-        type = t.bool;
-        description = "Whether to validate `${opts.settings}`.";
-        default = true;
-        example = false;
-      };
-      schema = l.mkOption {
-        type = t.path;
-        description = "The biome schema file to validate against";
-        defaultText = l.literalMD ''
-          Fetches `"https://biomejs.dev/schemas/''${biomeVersion}/schema.json"` using `pkgs.fetchurl`.
-        '';
-        default = p.fetchurl {
-          url = "https://biomejs.dev/schemas/${biomeVersion}/schema.json";
-          hash = schemaHashes.${biomeVersion};
-        };
-        example = l.literalExpression ''
-          pkgs.fetchurl {
-            url = "https://biomejs.dev/schemas/2.1.2/schema.json"
-            hash = "sha256-n4Y16J7g34e0VdQzRItu/P7n5oppkY4Vm4P1pQxOILU=";
-          }
-        '';
-      };
+    validate.enable = l.mkOption {
+      type = t.bool;
+      description = "Whether to validate `${opts.settings}`.";
+      default = true;
+      example = false;
     };
   };
 
@@ -139,7 +107,6 @@ in
     settings.formatter.biome.options =
       let
         jsonFile = json.generate "biome.json" cfg.settings;
-
         validatedConfig =
           p.runCommand "validated-biome-config.json"
             {
@@ -148,12 +115,11 @@ in
               ];
               env = {
                 json = jsonFile;
-                schema = cfg.validate.schema;
-                schemaPath = cfg.validate.schema.url or (toString cfg.validate.schema);
+                schema = "${cfg.package}/share/schema.json";
               };
             }
             ''
-              echo "Validating biome.json against schema $schemaPath..."
+              echo "Validating biome.json against schema $schema..."
               export HOME=$TMPDIR
               check-jsonschema --schemafile "$schema" "$json"
               cp "$json" $out


### PR DESCRIPTION
This pr uses the schema output that was introduced in: https://github.com/NixOS/nixpkgs/pull/476453 instead of `fetchurl`.
I also updated nixpkgs in flake.lock due to it being outdated and not working if it's not there.

The development of this feature was supported by DigitalBrewStudios.

Closes: #511