### PR TITLE
feat(kdlfmt): add formatCommand, config and flag

### DIFF
--- a/programs/kdlfmt.nix
+++ b/programs/kdlfmt.nix
@@ -1,14 +1,88 @@
-{ mkFormatterModule, ... }:
 {
-  meta.maintainers = [ ];
+  lib,
+  pkgs,
+  config,
+  mkFormatterModule,
+  ...
+}:
+let
+  cfg = config.programs.kdlfmt;
+in
+{
+  meta.maintainers = [ "tetov" ];
 
   imports = [
     (mkFormatterModule {
       name = "kdlfmt";
-      args = [ "format" ];
+      args = [ cfg.formatCommand ];
       includes = [
         "*.kdl"
       ];
     })
   ];
+
+  options.programs.kdlfmt = {
+    formatCommand = lib.mkOption {
+      type = lib.types.enum [
+        "format"
+        "check"
+      ];
+      description = "The command to run kdlfmt with.";
+      default = "format";
+      example = "check";
+    };
+    kdlVersion = lib.mkOption {
+      type = lib.types.enum [
+        "v1"
+        "v2"
+        null
+      ];
+      default = null;
+      description = "kdl specification to use. By default all versions are tried";
+    };
+    settings = lib.mkOption {
+      type =
+        with lib.types;
+        attrsOf (oneOf [
+          bool
+          int
+          str
+        ]);
+      description = "kdlfmt configuration.";
+      default = { };
+      example = {
+        indent_size = 4;
+        use_tabs = true;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    settings.formatter.kdlfmt.options =
+      let
+        inherit (lib)
+          concatMapAttrsStringSep
+          isAttrs
+          isBool
+          toString
+          ;
+        toSimpleKDL =
+          v:
+          if isAttrs v then
+            concatMapAttrsStringSep "\n" (key: value: "${key} ${toSimpleKDL value}") v
+          else if isBool v then
+            (if v then "#true" else "#false")
+          else
+            toString v;
+        kdlFile = pkgs.writeText "kdlfmt.kdl" (toSimpleKDL cfg.settings);
+      in
+      lib.optionals (cfg.settings != { }) [
+        "--config"
+        "${kdlFile}"
+      ]
+      ++ lib.optionals (cfg.kdlVersion != null) [
+        "--kdl-version"
+        cfg.kdlVersion
+      ];
+  };
 }


### PR DESCRIPTION
kdlfmt can both format and check, so added formatCommand.

It can also set kdl-version, and has a config file.

There's no generator for KDL in nixpkgs so I wrote a very simple one that is enough for the currently available settings and will probably be enough for some more if they are added later.

I've tested the settings, the version flag and using formatCommand check.