### PR TITLE
json-sort: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ functions.
 * [hujsonfmt](programs/hujsonfmt.nix)
 * [isort](programs/isort.nix)
 * [json-sort-cli](programs/json-sort-cli.nix)
+* [json-sort](programs/json-sort.nix)
 * [jsonfmt](programs/jsonfmt.nix)
 * [jsonnet-lint](programs/jsonnet-lint.nix)
 * [jsonnetfmt](programs/jsonnetfmt.nix)

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770107345,
-        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
         "type": "github"
       },
       "original": {

--- a/programs/json-sort.nix
+++ b/programs/json-sort.nix
@@ -1,0 +1,21 @@
+{
+  mkFormatterModule,
+  ...
+}:
+{
+  meta = {
+    maintainers = [
+      "drupol"
+    ];
+  };
+
+  imports = [
+    (mkFormatterModule {
+      name = "json-sort";
+      includes = [
+        "*.json"
+      ];
+      args = [ "--fix" ];
+    })
+  ];
+}


### PR DESCRIPTION
JSON-Sort: https://crates.io/crates/json-sort

A CLI tool that sorts JSON object keys to make comparisons and diffs easier, without reordering arrays. 