### PR TITLE
feat(alejandra): add settings option for indentation config

### DIFF
--- a/programs/alejandra.nix
+++ b/programs/alejandra.nix
@@ -1,4 +1,16 @@
-{ mkFormatterModule, ... }:
+{
+  lib,
+  pkgs,
+  config,
+  mkFormatterModule,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+
+  cfg = config.programs.alejandra;
+  configFormat = pkgs.formats.toml { };
+in
 {
   meta.maintainers = [ ];
 
@@ -8,4 +20,31 @@
       includes = [ "*.nix" ];
     })
   ];
+
+  options.programs.alejandra.settings = {
+    indentation = mkOption {
+      description = "Indentation style to use when formatting Nix files.";
+      type = types.nullOr (
+        types.enum [
+          "TwoSpaces"
+          "FourSpaces"
+          "Tabs"
+        ]
+      );
+      default = null;
+      example = "FourSpaces";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    settings.formatter.alejandra.options =
+      let
+        settings = lib.filterAttrsRecursive (_: v: v != null) cfg.settings;
+        configFile = configFormat.generate "alejandra.toml" settings;
+      in
+      lib.optionals (settings != { }) [
+        "--experimental-config"
+        (toString configFile)
+      ];
+  };
 }


### PR DESCRIPTION
Adds `settings` options for the alejandra formatter, enabling configuration via a generated `alejandra.toml`.

Closes #426

## Changes

- `programs/alejandra.nix`: add `programs.alejandra.settings.indentation` option (`TwoSpaces` | `FourSpaces` | `Tabs`, default `null`)

## Usage

```nix
programs.alejandra = {
  enable = true;
  settings.indentation = "FourSpaces";
};
```