### PR TITLE
default `projectRootFile` to `null`

### DIFF
--- a/module-options.nix
+++ b/module-options.nix
@@ -145,7 +145,7 @@ in
         build.wrapper.
         Set to null to let treefmt use its native detection.
       '';
-      default = ".git/config";
+      default = null;
       type = types.nullOr types.str;
     };
 

--- a/module-options.nix
+++ b/module-options.nix
@@ -143,9 +143,9 @@ in
       description = ''
         File to look for to determine the root of the project in the
         build.wrapper.
-        Set to null to let treefmt use its native detection.
+        Leave set to null to let treefmt use its native detection.
       '';
-      default = ".git/config";
+      default = null;
       type = types.nullOr types.str;
     };
 


### PR DESCRIPTION
Lets `treefmt` figure out the project root to fix root detection in git worktrees, implementing https://github.com/numtide/treefmt-nix/issues/373#issuecomment-3017042316.

Closes #373.