### PR TITLE
fix: add `*.heex` pattern to `mix-format`

### DIFF
--- a/examples/formatter-mix-format.toml
+++ b/examples/formatter-mix-format.toml
@@ -2,5 +2,5 @@
 [formatter.mix-format]
 command = "mix"
 excludes = []
-includes = ["*.ex", "*.exs"]
+includes = ["*.ex", "*.exs", "*.heex"]
 options = ["format"]

--- a/programs/mix-format.nix
+++ b/programs/mix-format.nix
@@ -11,6 +11,7 @@
       includes = [
         "*.ex"
         "*.exs"
+        "*.heex"
       ];
     })
   ];


### PR DESCRIPTION
This pattern is for the Phoenix HEEx template language.