### PR TITLE
latexindent: remove dependency on `texliveMedium`

### DIFF
--- a/programs/latexindent.nix
+++ b/programs/latexindent.nix
@@ -8,8 +8,10 @@
   imports = [
     (mkFormatterModule {
       name = "latexindent";
-      package = "texliveMedium";
-      mainProgram = "latexindent";
+      package = [
+        "texlivePackages"
+        "latexindent"
+      ];
       args = [ "-wd" ];
       includes = [
         "*.tex"


### PR DESCRIPTION
The `texliveMedium` scheme contains lots of unneeded TeX packages, hence replace it with `texlivePackages.latexindent`.
