### PR TITLE
Add more options to ruff-check

### DIFF
--- a/programs/ruff-check.nix
+++ b/programs/ruff-check.nix
@@ -58,6 +58,15 @@ in
       example = [ "F811" ];
       default = [ ];
     };
+    extendExclude = lib.mkOption {
+      description = ''
+        --force-exclude --extend-exclude options.
+        The --force-exclude is necessary because of the explicit file provisioning via treefmt.
+      '';
+      type = lib.types.listOf lib.types.str;
+      example = [ "src/**/*_generated.py" ];
+      default = [ ];
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -71,6 +80,11 @@ in
         ++ (lib.optionals ((builtins.length cfg.extendIgnore) != 0) [
           "--extend-ignore"
           (lib.concatStringsSep "," cfg.extendIgnore)
+        ])
+        ++ (lib.optionals ((builtins.length cfg.extendExclude) != 0) [
+          "--force-exclude"
+          "--extend-exclude"
+          (lib.concatStringsSep "," cfg.extendExclude)
         ]);
     };
   };

--- a/programs/ruff-check.nix
+++ b/programs/ruff-check.nix
@@ -50,14 +50,28 @@ in
       example = [ "I" ];
       default = [ ];
     };
+    extendIgnore = lib.mkOption {
+      description = ''
+        --extend-ignore options
+      '';
+      type = lib.types.listOf lib.types.str;
+      example = [ "F811" ];
+      default = [ ];
+    };
   };
 
   config = lib.mkIf cfg.enable {
     settings.formatter.ruff-check = {
-      options = lib.optionals ((builtins.length cfg.extendSelect) != 0) [
-        "--extend-select"
-        (lib.concatStringsSep "," cfg.extendSelect)
-      ];
+      options =
+        [ ]
+        ++ (lib.optionals ((builtins.length cfg.extendSelect) != 0) [
+          "--extend-select"
+          (lib.concatStringsSep "," cfg.extendSelect)
+        ])
+        ++ (lib.optionals ((builtins.length cfg.extendIgnore) != 0) [
+          "--extend-ignore"
+          (lib.concatStringsSep "," cfg.extendIgnore)
+        ]);
     };
   };
 }


### PR DESCRIPTION
I created this PR in favor of #509 to add more options while I wait for the PR to be merged.

Right now, this PR adds the following new options to `ruff-check`:
- `extendIgnore`: Ignore additional rule codes during linting
- `extendExclude`: Ignore additional files during linting (requires `--force-exclude` because of the explicit file provisioning via `treefmt`)

