### PR TITLE
Drop x86_64-darwin from supported systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,6 @@
       eachSystem = lib.genAttrs [
         "aarch64-darwin"
         "aarch64-linux"
-        "x86_64-darwin"
         "x86_64-linux"
       ];
     in


### PR DESCRIPTION
Nixpkgs 26.11 dropped support for `x86_64-darwin` (NixOS/nixpkgs#493096), which makes this flake fail to evaluate when used as a dependency on `nixpkgs-unstable` (post-26.11):

    error: Nixpkgs 26.11 has dropped support for x86_64-darwin.

Fixes #521