### PR TITLE
fix eval warning

### DIFF
--- a/module-options.nix
+++ b/module-options.nix
@@ -342,8 +342,8 @@ in
               git init --quiet
               git add .
               git commit -m init --quiet
-              export LANG=${if pkgs.stdenv.isDarwin then "en_US.UTF-8" else "C.UTF-8"}
-              export LC_ALL=${if pkgs.stdenv.isDarwin then "en_US.UTF-8" else "C.UTF-8"}
+              export LANG=${if pkgs.stdenv.hostPlatform.isDarwin then "en_US.UTF-8" else "C.UTF-8"}
+              export LC_ALL=${if pkgs.stdenv.hostPlatform.isDarwin then "en_US.UTF-8" else "C.UTF-8"}
               treefmt --version
               treefmt --no-cache
               git status --short


### PR DESCRIPTION
stdenv.isDarwin is deprecated, use stdenv.hostPlatform.isDarwin instead