### PR TITLE
feat(typos): add autoFix option

### DIFF
--- a/examples/formatter-typos.toml
+++ b/examples/formatter-typos.toml
@@ -3,4 +3,4 @@
 command = "typos"
 excludes = []
 includes = ["*"]
-options = ["--write-changes", "--force-exclude"]
+options = ["--force-exclude", "--write-changes"]

--- a/programs/typos.nix
+++ b/programs/typos.nix
@@ -29,7 +29,7 @@ in
       description = ''
         Write fixes out
 
-        Set to falkse to run typos in check-only mode; useful if you find that
+        Set to false to run typos in check-only mode; useful if you find that
         automatic corrections are often destructive or incorrect.
       '';
     };

--- a/programs/typos.nix
+++ b/programs/typos.nix
@@ -14,8 +14,6 @@ in
     (mkFormatterModule {
       name = "typos";
       args = [
-        "--write-changes"
-
         # Treefmt may pass files otherwise ignored by typos (e.g. files ignored in typos.toml).
         # '--force-exclude' stops typos from acting on any ignored files passed
         "--force-exclude"
@@ -25,6 +23,17 @@ in
   ];
 
   options.programs.typos = {
+    autoFix = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Write fixes out
+
+        Set to falkse to run typos in check-only mode; useful if you find that
+        automatic corrections are often destructive or incorrect.
+      '';
+    };
+
     threads = lib.mkOption {
       type = lib.types.nullOr lib.types.int;
       default = null;
@@ -142,6 +151,7 @@ in
           "--config"
           cfg.configFile
         ])
+        ++ lib.optional cfg.autoFix "--write-changes"
         ++ lib.optional cfg.sort "--sort"
         ++ lib.optional cfg.isolated "--isolated"
         ++ lib.optional cfg.hidden "--hidden"


### PR DESCRIPTION
Add an `autoFix` option to the `typos` formatter configuration. Default behaviour is unchanged (i.e., `autoFix = true`), but now users can easily opt-out.

Closes #535.